### PR TITLE
Backend implementation of merging exposures with hdrgen

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,7 +5,6 @@ mod merge_exposures;
 
 use merge_exposures::merge_exposures;
 
-
 fn main() {
     // === Define hardcoded data for testing ===
 
@@ -50,4 +49,3 @@ fn main() {
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
-

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,10 +6,7 @@ use std::process::Command;
 const DEBUG: bool = false;
 
 // Path to hdrgen executable
-const HDRGEN_PATH: &str = "../../hdrgen_macosx/bin/";
-
-// Directory for output HDR images
-// const OUTPUT_PATH: &str = "../../results/";
+const HDRGEN_PATH: &str = "/usr/local/bin/";
 
 fn main() {
     // === Define hardcoded data for testing ===
@@ -43,7 +40,7 @@ fn main() {
 
     let _fake_output_path = "../tmp/output1.hdr".to_string();
 
-    // Call merge_exposures with hardcoded data
+    // UNCOMMENT TO CALL MERGE_EXPOSURES WITH HARDCODED DATA
     // let _result = merge_exposures(
     //     _fake_input_images,
     //     _fake_response_function,
@@ -57,10 +54,12 @@ fn main() {
 }
 
 // Merges multiple LDR images into an HDR image using hdrgen.
-// input_images is a vector of the paths to the input images.
-//    Input images must be in .JPG format.
-// response_function is a string for the path to the
-//    camera response function, must be a .rsp file
+// input_images:
+//    vector of the paths to the input images. Input images must be in .JPG format.
+// response_function:
+//    string for the path to the camera response function, must be a .rsp file
+// output_path:
+//    a string for the path and filename where the resulting HDR image will be saved.
 #[tauri::command]
 fn merge_exposures(
     input_images: Vec<String>,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,8 +1,59 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use::std::process::Command;
+
+const DEBUG: bool = true;
+const HDRGEN_PATH: &str = "../../hdrgen_macosx/bin/hdrgen";
+
+
 fn main() {
+
+  let fake_input_images: Vec<String> = [
+    "../examples/inputs/input_images/IMG_6955.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6956.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6957.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6958.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6959.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6960.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6961.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6962.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6963.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6964.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6965.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6966.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6967.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6968.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6969.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6970.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6971.JPG".to_string(),
+    "../examples/inputs/input_images/IMG_6972.JPG".to_string()
+  ].to_vec();
+
+  let fake_response_function = "../examples/inputs/parameters/response_function_files/Response_function.rsp".to_string();
+
+  merge_exposures(fake_input_images, fake_response_function);
+
+
   tauri::Builder::default()
+    .invoke_handler(tauri::generate_handler![merge_exposures])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
+}
+
+
+#[tauri::command]
+fn merge_exposures(input_images: Vec<String>, response_function: String) -> Result<String, String> {
+
+  if DEBUG {
+    println!("merge_exposures Tauri command was called!");
+  }
+
+  let output_path = "../results/output1.hdr";
+
+
+  
+  
+  return Ok(output_path.into());
+
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,12 +1,10 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::process::Command;
+mod merge_exposures;
 
-const DEBUG: bool = false;
+use merge_exposures::merge_exposures;
 
-// Path to hdrgen executable
-const HDRGEN_PATH: &str = "/usr/local/bin/";
 
 fn main() {
     // === Define hardcoded data for testing ===
@@ -53,58 +51,3 @@ fn main() {
         .expect("error while running tauri application");
 }
 
-// Merges multiple LDR images into an HDR image using hdrgen.
-// input_images:
-//    vector of the paths to the input images. Input images must be in .JPG format.
-// response_function:
-//    string for the path to the camera response function, must be a .rsp file
-// output_path:
-//    a string for the path and filename where the resulting HDR image will be saved.
-#[tauri::command]
-fn merge_exposures(
-    input_images: Vec<String>,
-    response_function: String,
-    output_path: String,
-) -> Result<String, String> {
-    if DEBUG {
-        println!("merge_exposures Tauri command was called!");
-    }
-
-    // Create a new command for hdrgen
-    let mut command = Command::new(HDRGEN_PATH.to_string() + "hdrgen");
-
-    // Add input LDR images as args
-    for input_image in input_images {
-        command.arg(format!("{}", input_image));
-    }
-
-    // Add output path for HDR image
-    command.arg("-o");
-    command.arg(format!("{}", output_path));
-
-    // Add camera response function
-    command.arg("-r");
-    command.arg(format!("{}", response_function));
-
-    // Add remaining flags for hdrgen step
-    command.arg("-a");
-    command.arg("-e");
-    command.arg("-f");
-    command.arg("-g");
-
-    // Run the command
-    let status = command.status().unwrap();
-
-    if DEBUG {
-        println!("\nCommand exit status: {:?}\n", status);
-    }
-
-    // Return a Result object to indicate whether hdrgen command was successful
-    if status.success() {
-        // On success, return output path of HDR image
-        Ok(output_path.into())
-    } else {
-        // On error, return an error message
-        Err("Error, non-zero exit status. hdrgen command failed.".into())
-    }
-}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,9 +1,13 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-mod merge_exposures;
+// Import pipeline module
+mod pipeline;
+use pipeline::pipeline;
 
-use merge_exposures::merge_exposures;
+// Hardcoded radiance and hdrgen paths for backend testing
+const _FAKE_RADIANCE_PATH: &str = "/usr/local/radiance/bin/";
+const _FAKE_HDRGEN_PATH: &str = "/usr/local/bin/";
 
 fn main() {
     // === Define hardcoded data for testing ===
@@ -37,15 +41,34 @@ fn main() {
 
     let _fake_output_path = "../tmp/output1.hdr".to_string();
 
-    // UNCOMMENT TO CALL MERGE_EXPOSURES WITH HARDCODED DATA
-    // let _result = merge_exposures(
+    // Hardcoded temp path
+    let _fake_temp_path = "../tmp/".to_string();
+
+    // Hardcoded fisheye diameter and coordinates of square around fisheye view
+    let _fake_diameter = "3612".to_string();
+    let _fake_xleft = "1019".to_string();
+    let _fake_ydown = "74".to_string();
+
+    // Hardcoded HDR image resolution
+    let _fake_xdim = "1000".to_string();
+    let _fake_ydim = "1000".to_string();
+
+    // let _result = pipeline(
+    //     _FAKE_RADIANCE_PATH.to_string(),
+    //     _FAKE_HDRGEN_PATH.to_string(),
+    //     _fake_output_path,
+    //     _fake_temp_path,
     //     _fake_input_images,
     //     _fake_response_function,
-    //     _fake_output_path,
+    //     _fake_diameter,
+    //     _fake_xleft,
+    //     _fake_ydown,
+    //     _fake_xdim,
+    //     _fake_ydim,
     // );
 
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![merge_exposures])
+        .invoke_handler(tauri::generate_handler![pipeline])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,111 +1,111 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use::std::process::Command;
+use std::process::Command;
 
-const DEBUG: bool = true;
+const DEBUG: bool = false;
 
 // Path to hdrgen executable
 const HDRGEN_PATH: &str = "../../hdrgen_macosx/bin/";
 
 // Directory for output HDR images
-const OUTPUT_PATH: &str = "../results/";
+// const OUTPUT_PATH: &str = "../../results/";
 
 fn main() {
+    // === Define hardcoded data for testing ===
 
-  // === Define hardcoded data for testing ===
+    // Hardcoded input JPG image paths
+    let _fake_input_images: Vec<String> = [
+        "../examples/inputs/input_images/IMG_6955.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6956.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6957.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6958.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6959.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6960.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6961.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6962.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6963.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6964.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6965.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6966.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6967.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6968.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6969.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6970.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6971.JPG".to_string(),
+        "../examples/inputs/input_images/IMG_6972.JPG".to_string(),
+    ]
+    .to_vec();
 
-  // Hardcoded input JPG image paths
-  let fake_input_images: Vec<String> = [
-    "../examples/inputs/input_images/IMG_6955.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6956.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6957.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6958.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6959.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6960.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6961.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6962.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6963.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6964.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6965.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6966.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6967.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6968.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6969.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6970.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6971.JPG".to_string(),
-    "../examples/inputs/input_images/IMG_6972.JPG".to_string()
-  ].to_vec();
+    // Hardcoded camera response function path
+    let _fake_response_function =
+        "../examples/inputs/parameters/response_function_files/Response_function.rsp".to_string();
 
-  // Hardcoded camera response function path
-  let fake_response_function = "../examples/inputs/parameters/response_function_files/Response_function.rsp".to_string();
+    let _fake_output_path = "../tmp/output1.hdr".to_string();
 
-  // Call merge_exposures with hardcoded data
-  let _result = merge_exposures(fake_input_images, fake_response_function);
+    // Call merge_exposures with hardcoded data
+    // let _result = merge_exposures(
+    //     _fake_input_images,
+    //     _fake_response_function,
+    //     _fake_output_path,
+    // );
 
-
-  tauri::Builder::default()
-    // UNCOMMENT THE BELOW LINE WHEN THIS IS INTEGRATED WITH FRONTEND
-    // TO ALLOW merge_exposures COMMAND TO BE CALLED
-    // .invoke_handler(tauri::generate_handler![merge_exposures])
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![merge_exposures])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }
 
-
 // Merges multiple LDR images into an HDR image using hdrgen.
-// input_images is a vector of the paths to the input images. 
-//    Input images must be in .JPG format. 
-// response_function is a string for the path to the 
+// input_images is a vector of the paths to the input images.
+//    Input images must be in .JPG format.
+// response_function is a string for the path to the
 //    camera response function, must be a .rsp file
 #[tauri::command]
-fn merge_exposures(input_images: Vec<String>, response_function: String) -> Result<String, String> {
+fn merge_exposures(
+    input_images: Vec<String>,
+    response_function: String,
+    output_path: String,
+) -> Result<String, String> {
+    if DEBUG {
+        println!("merge_exposures Tauri command was called!");
+    }
 
-  if DEBUG {
-    println!("merge_exposures Tauri command was called!");
-  }
+    // Create a new command for hdrgen
+    let mut command = Command::new(HDRGEN_PATH.to_string() + "hdrgen");
 
-  let output_path = OUTPUT_PATH.to_string() + "output1.hdr";
+    // Add input LDR images as args
+    for input_image in input_images {
+        command.arg(format!("{}", input_image));
+    }
 
+    // Add output path for HDR image
+    command.arg("-o");
+    command.arg(format!("{}", output_path));
 
-  // Create a new command for hdrgen
-  let mut command = Command::new(HDRGEN_PATH.to_string() + "hdrgen");
+    // Add camera response function
+    command.arg("-r");
+    command.arg(format!("{}", response_function));
 
-  // Add input LDR images as args
-  for input_image in input_images {
-    command.arg(format!("{}", input_image));
-  }
+    // Add remaining flags for hdrgen step
+    command.arg("-a");
+    command.arg("-e");
+    command.arg("-f");
+    command.arg("-g");
 
-  // Add output path for HDR image
-  command.arg("-o");
-  command.arg(format!("{}", output_path));
+    // Run the command
+    let status = command.status().unwrap();
 
-  // Add camera response function
-  command.arg("-r");
-  command.arg(format!("{}", response_function));
+    if DEBUG {
+        println!("\nCommand exit status: {:?}\n", status);
+    }
 
-  // Add remaining flags for hdrgen step
-  command.arg("-a");
-  command.arg("-e");
-  command.arg("-f");
-  command.arg("-g");
-
-  // Run the command
-  let status = command.status().unwrap();
-  
-  if DEBUG {
-    println!("\nCommand exit status: {:?}\n", status);
-  }
-  
-
-  // Return a Result object to indicate whether hdrgen command was successful
-  if status.success() {
-    // On success, return output path of HDR image
-    Ok(output_path.into())
-  }
-  else {
-    // On error, return an error message
-    Err("Error, non-zero exit status. hdrgen command failed.".into())
-  }
-
+    // Return a Result object to indicate whether hdrgen command was successful
+    if status.success() {
+        // On success, return output path of HDR image
+        Ok(output_path.into())
+    } else {
+        // On error, return an error message
+        Err("Error, non-zero exit status. hdrgen command failed.".into())
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,10 +4,18 @@
 use::std::process::Command;
 
 const DEBUG: bool = true;
-const HDRGEN_PATH: &str = "../../hdrgen_macosx/bin/hdrgen";
+
+// Path to hdrgen executable
+const HDRGEN_PATH: &str = "../../hdrgen_macosx/bin/";
+
+// Directory for output HDR images
+const OUTPUT_PATH: &str = "../results/";
 
 fn main() {
 
+  // === Define hardcoded data for testing ===
+
+  // Hardcoded input JPG image paths
   let fake_input_images: Vec<String> = [
     "../examples/inputs/input_images/IMG_6955.JPG".to_string(),
     "../examples/inputs/input_images/IMG_6956.JPG".to_string(),
@@ -29,8 +37,10 @@ fn main() {
     "../examples/inputs/input_images/IMG_6972.JPG".to_string()
   ].to_vec();
 
+  // Hardcoded camera response function path
   let fake_response_function = "../examples/inputs/parameters/response_function_files/Response_function.rsp".to_string();
 
+  // Call merge_exposures with hardcoded data
   let _result = merge_exposures(fake_input_images, fake_response_function);
 
 
@@ -43,6 +53,11 @@ fn main() {
 }
 
 
+// Merges multiple LDR images into an HDR image using hdrgen.
+// input_images is a vector of the paths to the input images. 
+//    Input images must be in .JPG format. 
+// response_function is a string for the path to the 
+//    camera response function, must be a .rsp file
 #[tauri::command]
 fn merge_exposures(input_images: Vec<String>, response_function: String) -> Result<String, String> {
 
@@ -50,11 +65,11 @@ fn merge_exposures(input_images: Vec<String>, response_function: String) -> Resu
     println!("merge_exposures Tauri command was called!");
   }
 
-  let output_path = "../results/output1.hdr";
+  let output_path = OUTPUT_PATH.to_string() + "output1.hdr";
 
 
   // Create a new command for hdrgen
-  let mut command = Command::new(HDRGEN_PATH);
+  let mut command = Command::new(HDRGEN_PATH.to_string() + "hdrgen");
 
   // Add input LDR images as args
   for input_image in input_images {
@@ -83,11 +98,13 @@ fn merge_exposures(input_images: Vec<String>, response_function: String) -> Resu
   }
   
 
-  // Check if hdrgen command was successful
+  // Return a Result object to indicate whether hdrgen command was successful
   if status.success() {
+    // On success, return output path of HDR image
     Ok(output_path.into())
   }
-  else { 
+  else {
+    // On error, return an error message
     Err("Error, non-zero exit status. hdrgen command failed.".into())
   }
 

--- a/src-tauri/src/merge_exposures.rs
+++ b/src-tauri/src/merge_exposures.rs
@@ -1,0 +1,65 @@
+use std::process::Command;
+
+
+const DEBUG: bool = false;
+
+// Path to hdrgen executable
+const HDRGEN_PATH: &str = "/usr/local/bin/";
+
+
+
+// Merges multiple LDR images into an HDR image using hdrgen.
+// input_images:
+//    vector of the paths to the input images. Input images must be in .JPG format.
+// response_function:
+//    string for the path to the camera response function, must be a .rsp file
+// output_path:
+//    a string for the path and filename where the resulting HDR image will be saved.
+#[tauri::command]
+pub fn merge_exposures(
+    input_images: Vec<String>,
+    response_function: String,
+    output_path: String,
+) -> Result<String, String> {
+    if DEBUG {
+        println!("merge_exposures Tauri command was called!");
+    }
+
+    // Create a new command for hdrgen
+    let mut command = Command::new(HDRGEN_PATH.to_string() + "hdrgen");
+
+    // Add input LDR images as args
+    for input_image in input_images {
+        command.arg(format!("{}", input_image));
+    }
+
+    // Add output path for HDR image
+    command.arg("-o");
+    command.arg(format!("{}", output_path));
+
+    // Add camera response function
+    command.arg("-r");
+    command.arg(format!("{}", response_function));
+
+    // Add remaining flags for hdrgen step
+    command.arg("-a");
+    command.arg("-e");
+    command.arg("-f");
+    command.arg("-g");
+
+    // Run the command
+    let status = command.status().unwrap();
+
+    if DEBUG {
+        println!("\nCommand exit status: {:?}\n", status);
+    }
+
+    // Return a Result object to indicate whether hdrgen command was successful
+    if status.success() {
+        // On success, return output path of HDR image
+        Ok(output_path.into())
+    } else {
+        // On error, return an error message
+        Err("Error, non-zero exit status. hdrgen command failed.".into())
+    }
+}

--- a/src-tauri/src/merge_exposures.rs
+++ b/src-tauri/src/merge_exposures.rs
@@ -1,12 +1,9 @@
 use std::process::Command;
 
-
 const DEBUG: bool = false;
 
 // Path to hdrgen executable
 const HDRGEN_PATH: &str = "/usr/local/bin/";
-
-
 
 // Merges multiple LDR images into an HDR image using hdrgen.
 // input_images:

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1,11 +1,11 @@
+mod crop;
 mod merge_exposures;
 mod nullify_exposure_value;
-mod crop;
 mod resize;
 
+use crop::crop;
 use merge_exposures::merge_exposures;
 use nullify_exposure_value::nullify_exposure_value;
-use crop::crop;
 use resize::resize;
 
 // Used to print out debug information
@@ -88,18 +88,17 @@ pub fn pipeline(
     );
 
     // If the command to merge exposures encountered an error, abort pipeline
-    if merge_exposures_result.is_err() {
-        return merge_exposures_result;
-    };
+    // if merge_exposures_result.is_err() {
+    //     return merge_exposures_result;
+    // };
 
-  
     // Nullify the exposure value
     let nullify_exposure_result = nullify_exposure_value(
         &config_settings,
         format!("{}output1.hdr", config_settings.temp_path),
         format!("{}output2.hdr", config_settings.temp_path),
     );
-  
+
     // If the command to nullify the exposure value encountered an error, abort pipeline
     if nullify_exposure_result.is_err() {
         return nullify_exposure_result;

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1,0 +1,85 @@
+mod merge_exposures;
+
+use merge_exposures::merge_exposures;
+
+// Used to print out debug information
+pub const DEBUG: bool = true;
+
+// Struct to hold some configuration settings (e.g. path settings).
+// Used when various stages of the pipeline are called.
+pub struct ConfigSettings {
+    radiance_path: String,
+    hdrgen_path: String,
+    output_path: String,
+    temp_path: String,
+}
+
+// Runs the radiance and hdrgen pipeline.
+// radiance_path:
+//      The path to radiance binaries
+// hdrgen_path:
+//      The path to the hdrgen binary
+// output_path: (NOT CURRENTLY USED)
+//      Place for final HDR image to be stored
+// temp_path: (CURRENTLY WHERE OUTPUTS ARE STORED)
+//      Place for intermediate HDR image outputs to be stored
+// input_images:
+//      vector of the paths to the input images. Input images must be in .JPG format.
+// response_function:
+//      string for the path to the camera response function, must be a .rsp file
+// diameter:
+//      the fisheye view diameter in pixels
+// xleft:
+//      The x-coordinate of the bottom left corner of the circumscribed square
+//      of the fisheye view (in pixels)
+// ydown:
+//      The y-coordinate of the bottom left corner of the circumscribed square
+//      of the fisheye view (in pixels)
+// xdim:
+//      The x-dimensional resolution to resize the HDR image to (in pixels)
+// ydim:
+//      The y-dimensional resolution to resize the HDR image to (in pixels)
+#[tauri::command]
+pub fn pipeline(
+    radiance_path: String,
+    hdrgen_path: String,
+    output_path: String,
+    temp_path: String,
+    input_images: Vec<String>,
+    response_function: String,
+    diameter: String,
+    xleft: String,
+    ydown: String,
+    xdim: String,
+    ydim: String,
+) -> Result<String, String> {
+    if DEBUG {
+        println!("Pipeline module called...");
+        println!("\tradiance path: {radiance_path}");
+        println!("\thdrgen path: {hdrgen_path}");
+        println!("\toutput path: {output_path}");
+        println!("\ttemp path: {temp_path}");
+        println!("\tinput images: {:?}", input_images);
+        println!("\tresponse function: {response_function}");
+        println!("\tdiameter: {diameter}");
+        println!("\txleft: {xleft}");
+        println!("\tydown: {ydown}");
+    }
+
+    // Add path to radiance and temp directory info to config settings
+    let config_settings = ConfigSettings {
+        radiance_path: radiance_path,
+        hdrgen_path: hdrgen_path,
+        output_path: output_path,
+        temp_path: temp_path,
+    };
+
+    let merge_exposures_result = merge_exposures(
+        &config_settings,
+        input_images,
+        response_function,
+        format!("{}output1.hdr", config_settings.temp_path),
+    );
+
+    return merge_exposures_result;
+}

--- a/src-tauri/src/pipeline/merge_exposures.rs
+++ b/src-tauri/src/pipeline/merge_exposures.rs
@@ -1,9 +1,9 @@
+use crate::pipeline::DEBUG;
+use std::fs::File;
 use std::process::Command;
+use std::process::Stdio;
 
-const DEBUG: bool = false;
-
-// Path to hdrgen executable
-const HDRGEN_PATH: &str = "/usr/local/bin/";
+use super::ConfigSettings;
 
 // Merges multiple LDR images into an HDR image using hdrgen.
 // input_images:
@@ -14,6 +14,7 @@ const HDRGEN_PATH: &str = "/usr/local/bin/";
 //    a string for the path and filename where the resulting HDR image will be saved.
 #[tauri::command]
 pub fn merge_exposures(
+    config_settings: &ConfigSettings,
     input_images: Vec<String>,
     response_function: String,
     output_path: String,
@@ -23,7 +24,7 @@ pub fn merge_exposures(
     }
 
     // Create a new command for hdrgen
-    let mut command = Command::new(HDRGEN_PATH.to_string() + "hdrgen");
+    let mut command = Command::new(config_settings.hdrgen_path.to_string() + "hdrgen");
 
     // Add input LDR images as args
     for input_image in input_images {

--- a/src-tauri/src/pipeline/merge_exposures.rs
+++ b/src-tauri/src/pipeline/merge_exposures.rs
@@ -1,7 +1,5 @@
 use crate::pipeline::DEBUG;
-use std::fs::File;
 use std::process::Command;
-use std::process::Stdio;
 
 use super::ConfigSettings;
 


### PR DESCRIPTION
Backend Rust implementation of merging multiple LDR images to form an HDR image using hdrgen.

Currently uses hardcoded paths for input LDR images and camera response function because this hasn't been integrated with the frontend yet.

There are path variables for both hdrgen and the directory for the output image for now. We can change this and do it a different way later, but I thought it's the easiest way for the moment. Let me know if a different way is preferred.

### *Note:*
To run this successfully, you'll need to change the HDRGEN_PATH to match the location of hdrgen on your system.

You also need to uncomment `main.rs:41` to run the hardcoded version since the integration with the frontend has not been completed yet.

And you'll need to either:
- create a `tmp/` directory inside the repo's directory, or
- change the `OUTPUT_PATH` to somewhere else to store the images

Additionally, the HDR image (output1.hdr) will need to be deleted between each run, otherwise hdrgen fails because the output file already exists. 

<br>
<br>

Closes #32.