### PR TITLE
Backend implementation of nullifying exposure value of HDR image

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,24 +1,33 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-mod nullify_exposure_value;
+// Import pipeline module
+mod pipeline;
+use pipeline::pipeline;
 
-use nullify_exposure_value::nullify_exposure_value;
+// Hardcoded radiance and hdrgen paths for backend testing
+const _FAKE_RADIANCE_PATH: &str = "/usr/local/radiance/bin/";
+const _FAKE_HDRGEN_PATH: &str = "/usr/local/bin/";
 
 fn main() {
     // === Define hardcoded data for testing ===
 
-    // Hardcoded input HDR image path
-    let _fake_input_image = "../tmp/output1.hdr".to_string();
+    // Hardcoded output path
+    let _fake_output_path = "../output/".to_string();
 
-    // Hardcoded output HDR image path
-    let _fake_output_path = "../tmp/output2.hdr".to_string();
+    // Hardcoded temp path
+    let _fake_temp_path = "../tmp/".to_string();
 
-    // UNCOMMENT TO CALL NULLIFY_EXPOSURE_VALUE WITH HARDCODED DATA
-    // let _result = nullify_exposure_value(_fake_input_image, _fake_output_path);
+    // UNCOMMENT TO CALL PIPELINE WITH HARDCODED DATA
+    // let _result = pipeline(
+    //     _FAKE_RADIANCE_PATH.to_string(),
+    //     _FAKE_HDRGEN_PATH.to_string(),
+    //     _fake_output_path,
+    //     _fake_temp_path,
+    // );
 
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![nullify_exposure_value])
+        .invoke_handler(tauri::generate_handler![pipeline])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,8 +1,27 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod nullify_exposure_value;
+
+use nullify_exposure_value::nullify_exposure_value;
+
 fn main() {
-  tauri::Builder::default()
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    // === Define hardcoded data for testing ===
+
+    // Hardcoded input HDR image path
+    let _fake_input_image = "../tmp/output1.hdr".to_string();
+
+    // Hardcoded output HDR image path
+    let _fake_output_path = "../tmp/output1.hdr".to_string();
+
+    // UNCOMMENT TO CALL NULLIFY_EXPOSURE_VALUE WITH HARDCODED DATA
+    // let _result = nullify_exposure_value(
+    //     _fake_input_image,
+    //     _fake_output_path,
+    // );
+
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![nullify_exposure_value])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,12 +19,12 @@ fn main() {
     let _fake_temp_path = "../tmp/".to_string();
 
     // UNCOMMENT TO CALL PIPELINE WITH HARDCODED DATA
-    // let _result = pipeline(
-    //     _FAKE_RADIANCE_PATH.to_string(),
-    //     _FAKE_HDRGEN_PATH.to_string(),
-    //     _fake_output_path,
-    //     _fake_temp_path,
-    // );
+    let _result = pipeline(
+        _FAKE_RADIANCE_PATH.to_string(),
+        _FAKE_HDRGEN_PATH.to_string(),
+        _fake_output_path,
+        _fake_temp_path
+    );
 
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![pipeline])

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,13 +12,10 @@ fn main() {
     let _fake_input_image = "../tmp/output1.hdr".to_string();
 
     // Hardcoded output HDR image path
-    let _fake_output_path = "../tmp/output1.hdr".to_string();
+    let _fake_output_path = "../tmp/output2.hdr".to_string();
 
     // UNCOMMENT TO CALL NULLIFY_EXPOSURE_VALUE WITH HARDCODED DATA
-    // let _result = nullify_exposure_value(
-    //     _fake_input_image,
-    //     _fake_output_path,
-    // );
+    // let _result = nullify_exposure_value(_fake_input_image, _fake_output_path);
 
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![nullify_exposure_value])

--- a/src-tauri/src/nullify_exposure_value.rs
+++ b/src-tauri/src/nullify_exposure_value.rs
@@ -19,15 +19,8 @@ pub fn nullify_exposure_value(input_image: String, output_path: String) -> Resul
     // Create a new command for ra_xyze
     let mut command = Command::new(RADIANCE_PATH.to_string() + "ra_xyze");
 
-    // Add flags for ra_xyze step
-    command.arg("-r");
-    command.arg("-o");
-
-    // Add input HDR image as arg
-    command.arg(format!("{}", input_image));
-
-    // Add output path for HDR image
-    command.arg(format!("{}", output_path));
+    // Add arguments to ra_xyze command
+    command.args(["-r", "-o", input_image.as_str(), output_path.as_str()]);
 
     // Run the command
     let status = command.status().unwrap();

--- a/src-tauri/src/nullify_exposure_value.rs
+++ b/src-tauri/src/nullify_exposure_value.rs
@@ -2,16 +2,49 @@ use std::process::Command;
 
 const DEBUG: bool = false;
 
-// Path to radiance
+// Path to radiance executables
 const RADIANCE_PATH: &str = "/usr/local/radiance/bin/";
 
+// Nullifies the exposure value of an HDR image using ra_xyze.
 // input_image:
-//    the paths to the input HDR image. Input image must be in .hdr format.
+//    the path to the input HDR image. Input image must be in .hdr format.
 // output_path:
 //    a string for the path and filename where the HDR image with nullified exposure value will be saved.
 #[tauri::command]
 pub fn nullify_exposure_value(input_image: String, output_path: String) -> Result<String, String> {
-    println!("Nullify exposure value was called!!");
+    if DEBUG {
+        println!("nullify_exposure_value was called!");
+    }
 
-    return Err("Nullify exposure value not implemented yet.".into());
+    // Create a new command for ra_xyze
+    let mut command = Command::new(RADIANCE_PATH.to_string() + "ra_xyze");
+
+    // Add flags for ra_xyze step
+    command.arg("-r");
+    command.arg("-o");
+
+    // Add input HDR image as arg
+    command.arg(format!("{}", input_image));
+
+    // Add output path for HDR image
+    command.arg(format!("{}", output_path));
+
+    // Run the command
+    let status = command.status().unwrap();
+
+    if DEBUG {
+        println!(
+            "\nNullication of exposure value command exit status: {:?}\n",
+            status
+        );
+    }
+
+    // Return a Result object to indicate whether ra_xyze command was successful
+    if status.success() {
+        // On success, return output path of HDR image
+        Ok(output_path.into())
+    } else {
+        // On error, return an error message
+        Err("Error, non-zero exit status. ra_xyze command failed.".into())
+    }
 }

--- a/src-tauri/src/nullify_exposure_value.rs
+++ b/src-tauri/src/nullify_exposure_value.rs
@@ -1,0 +1,17 @@
+use std::process::Command;
+
+const DEBUG: bool = false;
+
+// Path to radiance
+const RADIANCE_PATH: &str = "/usr/local/radiance/bin/";
+
+// input_image:
+//    the paths to the input HDR image. Input image must be in .hdr format.
+// output_path:
+//    a string for the path and filename where the HDR image with nullified exposure value will be saved.
+#[tauri::command]
+pub fn nullify_exposure_value(input_image: String, output_path: String) -> Result<String, String> {
+    println!("Nullify exposure value was called!!");
+
+    return Err("Nullify exposure value not implemented yet.".into());
+}

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1,0 +1,55 @@
+mod nullify_exposure_value;
+
+use nullify_exposure_value::nullify_exposure_value;
+
+// Used to print out debug information
+pub const DEBUG: bool = true;
+
+// Struct to hold some configuration settings (e.g. path settings).
+// Used when various stages of the pipeline are called.
+pub struct ConfigSettings {
+    radiance_path: String,
+    // hdrgen_path: String,
+    // output_path: String,
+    temp_path: String,
+}
+
+// Runs the radiance and hdrgen pipeline.
+// radiance_path:
+//      The path to radiance binaries
+// hdrgen_path:
+//      The path to the hdrgen binary
+// output_path: (NOT CURRENTLY USED)
+//      Place for final HDR image to be stored
+// temp_path: (CURRENTLY WHERE OUTPUTS ARE STORED)
+//      Place for intermediate HDR image outputs to be stored
+#[tauri::command]
+pub fn pipeline(
+    radiance_path: String,
+    hdrgen_path: String,
+    output_path: String,
+    temp_path: String,
+) -> Result<String, String> {
+    if DEBUG {
+        println!("Pipeline module called...");
+        println!("\tradiance path: {radiance_path}");
+        println!("\thdrgen path: {hdrgen_path}");
+        println!("\toutput path: {output_path}");
+        println!("\ttemp path: {temp_path}");
+    }
+
+    // Add path to radiance and temp directory info to config settings
+    let config_settings = ConfigSettings {
+        radiance_path: radiance_path,
+        // _hdrgen_path: hdrgen_path,
+        // _output_path: output_path,
+        temp_path: temp_path,
+    };
+
+    // Currently just run nullify_exposure_value and directly return result
+    return nullify_exposure_value(
+        &config_settings,
+        format!("{}output1.hdr", config_settings.temp_path),
+        format!("{}output2.hdr", config_settings.temp_path),
+    );
+}

--- a/src-tauri/src/pipeline/nullify_exposure_value.rs
+++ b/src-tauri/src/pipeline/nullify_exposure_value.rs
@@ -1,26 +1,30 @@
+use crate::pipeline::DEBUG;
 use std::process::Command;
 
-const DEBUG: bool = false;
-
-// Path to radiance executables
-const RADIANCE_PATH: &str = "/usr/local/radiance/bin/";
+use super::ConfigSettings;
 
 // Nullifies the exposure value of an HDR image using ra_xyze.
-// input_image:
+// config_settings:
+//    contains config settings - used for path to radiance and temp directory
+// input_file:
 //    the path to the input HDR image. Input image must be in .hdr format.
-// output_path:
-//    a string for the path and filename where the HDR image with nullified exposure value will be saved.
-#[tauri::command]
-pub fn nullify_exposure_value(input_image: String, output_path: String) -> Result<String, String> {
+// output_file:
+//    a string for the path and filename where the HDR image with nullified
+//    exposure value will be saved.
+pub fn nullify_exposure_value(
+    config_settings: &ConfigSettings,
+    input_file: String,
+    output_file: String,
+) -> Result<String, String> {
     if DEBUG {
         println!("nullify_exposure_value was called!");
     }
 
     // Create a new command for ra_xyze
-    let mut command = Command::new(RADIANCE_PATH.to_string() + "ra_xyze");
+    let mut command = Command::new(config_settings.radiance_path.to_string() + "ra_xyze");
 
     // Add arguments to ra_xyze command
-    command.args(["-r", "-o", input_image.as_str(), output_path.as_str()]);
+    command.args(["-r", "-o", input_file.as_str(), output_file.as_str()]);
 
     // Run the command
     let status = command.status().unwrap();
@@ -35,7 +39,7 @@ pub fn nullify_exposure_value(input_image: String, output_path: String) -> Resul
     // Return a Result object to indicate whether ra_xyze command was successful
     if status.success() {
         // On success, return output path of HDR image
-        Ok(output_path.into())
+        Ok(output_file.into())
     } else {
         // On error, return an error message
         Err("Error, non-zero exit status. ra_xyze command failed.".into())


### PR DESCRIPTION
This is structured a little differently than the current implementation of merging LDR images. Here, I decided to make a pipeline module, with the functionality to nullify the exposure value of the HDR image contained within a submodule of pipeline. That way, the main rust file only has to interact directly with pipeline and there should be less things in *main.rs* as things get more complicated.

### *Note:*
To run this successfully, you'll need to change the `_FAKE_RADIANCE_PATH` to match the location of the radiance binaries on your system.

You also need to uncomment `main.rs:22` to `27` where indicated to run the hardcoded version since the integration with the frontend has not been completed yet.

And you'll need to either:
- create a *tmp/* directory inside the repo's directory, or
- change the `_fake_temp_path` to somewhere else to store the images

Additionally, the initial HDR image (named *output1.hdr*, from the hdrgen step to merge LDR exposures) will need to be in the *tmp* folder already, otherwise the command will fail. 

Currently, the `_fake_output_path` passed to the pipeline (and then to `nullify_exposure_value`) is not used. Since this step of the pipeline should be occurring in the middle, I thought I'd leave it writing the file to *tmp/*. Can be changed later.

HDR image with nullified exposure value is written to *tmp/output2.hdr* at the base level of the repo's directory.

<br>
<br>


Closes #40
