### PR TITLE
Backend implementation of cropping and resizing HDR image

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,8 +1,40 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+// Import pipeline module
+mod pipeline;
+use pipeline::pipeline;
+
+// Hardcoded radiance and hdrgen paths for backend testing
+const _FAKE_RADIANCE_PATH: &str = "/usr/local/radiance/bin/";
+const _FAKE_HDRGEN_PATH: &str = "/usr/local/bin/";
+
 fn main() {
-  tauri::Builder::default()
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    // === Define hardcoded data for testing ===
+
+    // Hardcoded output path
+    let _fake_output_path = "../output/".to_string();
+
+    // Hardcoded temp path
+    let _fake_temp_path = "../tmp/".to_string();
+
+    let _fake_diameter = "3612".to_string();
+    let _fake_xleft = "1019".to_string();
+    let _fake_ydown = "74".to_string();
+
+    // UNCOMMENT TO CALL PIPELINE WITH HARDCODED DATA
+    // let _result = pipeline(
+    //     _FAKE_RADIANCE_PATH.to_string(),
+    //     _FAKE_HDRGEN_PATH.to_string(),
+    //     _fake_output_path,
+    //     _fake_temp_path,
+    //     _fake_diameter,
+    //     _fake_xleft,
+    //     _fake_ydown
+    // );
+
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![pipeline])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -23,15 +23,15 @@ fn main() {
     let _fake_ydown = "74".to_string();
 
     // UNCOMMENT TO CALL PIPELINE WITH HARDCODED DATA
-    // let _result = pipeline(
-    //     _FAKE_RADIANCE_PATH.to_string(),
-    //     _FAKE_HDRGEN_PATH.to_string(),
-    //     _fake_output_path,
-    //     _fake_temp_path,
-    //     _fake_diameter,
-    //     _fake_xleft,
-    //     _fake_ydown
-    // );
+    let _result = pipeline(
+        _FAKE_RADIANCE_PATH.to_string(),
+        _FAKE_HDRGEN_PATH.to_string(),
+        _fake_output_path,
+        _fake_temp_path,
+        _fake_diameter,
+        _fake_xleft,
+        _fake_ydown,
+    );
 
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![pipeline])

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,8 +24,8 @@ fn main() {
     let _fake_ydown = "74".to_string();
 
     // Hardcoded HDR image resolution
-    let _fake_xdim = "5616".to_string();
-    let _fake_ydim = "3744".to_string();
+    let _fake_xdim = "1000".to_string();
+    let _fake_ydim = "1000".to_string();
 
     // UNCOMMENT TO CALL PIPELINE WITH HARDCODED DATA
     // let _result = pipeline(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,20 +18,27 @@ fn main() {
     // Hardcoded temp path
     let _fake_temp_path = "../tmp/".to_string();
 
+    // Hardcoded fisheye diameter and coordinates of square around fisheye view
     let _fake_diameter = "3612".to_string();
     let _fake_xleft = "1019".to_string();
     let _fake_ydown = "74".to_string();
 
+    // Hardcoded HDR image resolution
+    let _fake_xdim = "5616".to_string();
+    let _fake_ydim = "3744".to_string();
+
     // UNCOMMENT TO CALL PIPELINE WITH HARDCODED DATA
-    let _result = pipeline(
-        _FAKE_RADIANCE_PATH.to_string(),
-        _FAKE_HDRGEN_PATH.to_string(),
-        _fake_output_path,
-        _fake_temp_path,
-        _fake_diameter,
-        _fake_xleft,
-        _fake_ydown,
-    );
+    // let _result = pipeline(
+    //     _FAKE_RADIANCE_PATH.to_string(),
+    //     _FAKE_HDRGEN_PATH.to_string(),
+    //     _fake_output_path,
+    //     _fake_temp_path,
+    //     _fake_diameter,
+    //     _fake_xleft,
+    //     _fake_ydown,
+    //     _fake_xdim,
+    //     _fake_ydim,
+    // );
 
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![pipeline])

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -68,8 +68,8 @@ pub fn pipeline(
     // Add path to radiance and temp directory info to config settings
     let config_settings = ConfigSettings {
         radiance_path: radiance_path,
-        _hdrgen_path: hdrgen_path,
-        _output_path: output_path,
+        hdrgen_path: hdrgen_path,
+        output_path: output_path,
         temp_path: temp_path,
     };
   
@@ -80,7 +80,7 @@ pub fn pipeline(
         format!("{}output2.hdr", config_settings.temp_path),
     );
   
-    if nullify_exposure_result.iserr() {
+    if nullify_exposure_result.is_err() {
         return nullify_exposure_result;
     }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -5,7 +5,7 @@ use crop::crop;
 // use resize::resize;
 
 // Used to print out debug information
-pub const DEBUG: bool = false;
+pub const DEBUG: bool = true;
 
 // Struct to hold some configuration settings (e.g. path settings).
 // Used when various stages of the pipeline are called.

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1,0 +1,70 @@
+mod crop;
+// mod resize;
+
+use crop::crop;
+// use resize::resize;
+
+// Used to print out debug information
+pub const DEBUG: bool = false;
+
+// Struct to hold some configuration settings (e.g. path settings).
+// Used when various stages of the pipeline are called.
+pub struct ConfigSettings {
+    radiance_path: String,
+    // hdrgen_path: String,
+    // output_path: String,
+    temp_path: String,
+}
+
+// Runs the radiance and hdrgen pipeline.
+// radiance_path:
+//      The path to radiance binaries
+// hdrgen_path:
+//      The path to the hdrgen binary
+// output_path: (NOT CURRENTLY USED)
+//      Place for final HDR image to be stored
+// temp_path: (CURRENTLY WHERE OUTPUTS ARE STORED)
+//      Place for intermediate HDR image outputs to be stored
+#[tauri::command]
+pub fn pipeline(
+    radiance_path: String,
+    hdrgen_path: String,
+    output_path: String,
+    temp_path: String,
+    diameter: String,
+    xleft: String,
+    ydown: String,
+) -> Result<String, String> {
+    if DEBUG {
+        println!("Pipeline module called...");
+        println!("\tradiance path: {radiance_path}");
+        println!("\thdrgen path: {hdrgen_path}");
+        println!("\toutput path: {output_path}");
+        println!("\ttemp path: {temp_path}");
+        println!("\tdiameter: {diameter}");
+        println!("\txleft: {xleft}");
+        println!("\tydown: {ydown}");
+    }
+
+    // Add path to radiance and temp directory info to config settings
+    let config_settings = ConfigSettings {
+        radiance_path: radiance_path,
+        // _hdrgen_path: hdrgen_path,
+        // _output_path: output_path,
+        temp_path: temp_path,
+    };
+
+    // Run function to crop and directly return result
+    let crop_result = crop(
+        &config_settings,
+        format!("{}output2.hdr", config_settings.temp_path),
+        format!("{}output3.hdr", config_settings.temp_path),
+        diameter,
+        xleft,
+        ydown,
+    );
+
+    // if crop_result.is_err() {
+    return crop_result;
+    // }
+}

--- a/src-tauri/src/pipeline/crop.rs
+++ b/src-tauri/src/pipeline/crop.rs
@@ -1,0 +1,22 @@
+use crate::pipeline::DEBUG;
+use std::process::Command;
+
+use super::ConfigSettings;
+
+pub fn crop(
+    config_settings: &ConfigSettings,
+    input_file: String,
+    output_file: String,
+    diameter: String,
+    xleft: String,
+    ydown: String,
+) -> Result<String, String> {
+    if DEBUG {
+        println!("crop was called! With parameters");
+        println!("\tdiameter: {diameter}");
+        println!("\txleft: {xleft}");
+        println!("\tydown: {ydown}");
+    }
+
+    return Err("Crop not implemented yet.".into());
+}

--- a/src-tauri/src/pipeline/crop.rs
+++ b/src-tauri/src/pipeline/crop.rs
@@ -1,8 +1,25 @@
 use crate::pipeline::DEBUG;
+use std::fs::File;
 use std::process::Command;
+use std::process::Stdio;
 
 use super::ConfigSettings;
 
+// Crops a fisheye view HDR image to a square which circumscribes the circular fisheye view.
+// config_settings:
+//      contains config settings - used for path to radiance and temp directory
+// input_file:
+//      the path to the input HDR image. Input image must be in .hdr format.
+// output_file:
+//      a string for the path and filename where the cropped HDR image will be saved.
+// diameter:
+//      the fisheye view diameter in pixels
+// xleft:
+//      The x-coordinate of the bottom left corner of the circumscribed square
+//      of the fisheye view (in pixels)
+// ydown:
+//      The y-coordinate of the bottom left corner of the circumscribed square
+//      of the fisheye view (in pixels)
 pub fn crop(
     config_settings: &ConfigSettings,
     input_file: String,
@@ -18,5 +35,39 @@ pub fn crop(
         println!("\tydown: {ydown}");
     }
 
-    return Err("Crop not implemented yet.".into());
+    // Create a new command for pcompos
+    let mut command = Command::new(config_settings.radiance_path.to_string() + "pcompos");
+
+    // Add arguments to pcompos command
+    command.args([
+        "-x",
+        diameter.as_str(),
+        "-y",
+        diameter.as_str(),
+        input_file.as_str(),
+        format!("-{xleft}").as_str(),
+        format!("-{ydown}").as_str(),
+        // output_file.as_str(),
+    ]);
+
+    // Direct command's output to specifed output file
+    let file = File::create(format!("{}output3.hdr", config_settings.temp_path)).unwrap();
+    let stdio = Stdio::from(file);
+    command.stdout(stdio);
+
+    // Run the command
+    let status = command.status().unwrap();
+
+    if DEBUG {
+        println!("\nCrop command exit status: {:?}\n", status);
+    }
+
+    // Return a Result object to indicate whether command was successful
+    if status.success() {
+        // On success, return output path of HDR image
+        Ok(output_file.into())
+    } else {
+        // On error, return an error message
+        Err("Error, non-zero exit status. Crop (pcompos command) failed.".into())
+    }
 }

--- a/src-tauri/src/pipeline/crop.rs
+++ b/src-tauri/src/pipeline/crop.rs
@@ -29,7 +29,7 @@ pub fn crop(
     ydown: String,
 ) -> Result<String, String> {
     if DEBUG {
-        println!("crop was called! With parameters");
+        println!("crop() was called with parameters:");
         println!("\tdiameter: {diameter}");
         println!("\txleft: {xleft}");
         println!("\tydown: {ydown}");
@@ -47,11 +47,10 @@ pub fn crop(
         input_file.as_str(),
         format!("-{xleft}").as_str(),
         format!("-{ydown}").as_str(),
-        // output_file.as_str(),
     ]);
 
     // Direct command's output to specifed output file
-    let file = File::create(format!("{}output3.hdr", config_settings.temp_path)).unwrap();
+    let file = File::create(&output_file).unwrap();
     let stdio = Stdio::from(file);
     command.stdout(stdio);
 
@@ -68,6 +67,6 @@ pub fn crop(
         Ok(output_file.into())
     } else {
         // On error, return an error message
-        Err("Error, non-zero exit status. Crop (pcompos command) failed.".into())
+        Err("Error, non-zero exit status. Crop command (pcompos) failed.".into())
     }
 }

--- a/src-tauri/src/pipeline/resize.rs
+++ b/src-tauri/src/pipeline/resize.rs
@@ -1,0 +1,33 @@
+use crate::pipeline::DEBUG;
+// use std::fs::File;
+use std::process::Command;
+// use std::process::Stdio;
+
+use super::ConfigSettings;
+
+// Resizes an HDR image to the target x and y resolution.
+// config_settings:
+//      contains config settings - used for path to radiance and temp directory
+// input_file:
+//      the path to the input HDR image. Input image must be in .hdr format.
+// output_file:
+//      a string for the path and filename where the cropped HDR image will be saved.
+// xdim:
+//      The x-dimensional resolution to resize the HDR image to (in pixels)
+// ydim:
+//      The y-dimensional resolution to resize the HDR image to (in pixels)
+pub fn resize(
+    config_settings: &ConfigSettings,
+    input_file: String,
+    output_file: String,
+    xdim: String,
+    ydim: String,
+) -> Result<String, String> {
+    if DEBUG {
+        println!("resize was called! With parameters");
+        println!("\txdim: {xdim}");
+        println!("\tydim: {ydim}");
+    }
+
+    return Err("Resize hasn't been implemented yet!".into());
+}

--- a/src-tauri/src/pipeline/resize.rs
+++ b/src-tauri/src/pipeline/resize.rs
@@ -1,7 +1,7 @@
 use crate::pipeline::DEBUG;
-// use std::fs::File;
+use std::fs::File;
 use std::process::Command;
-// use std::process::Stdio;
+use std::process::Stdio;
 
 use super::ConfigSettings;
 
@@ -24,10 +24,42 @@ pub fn resize(
     ydim: String,
 ) -> Result<String, String> {
     if DEBUG {
-        println!("resize was called! With parameters");
+        println!("resize() was called with parameters:");
         println!("\txdim: {xdim}");
         println!("\tydim: {ydim}");
     }
 
-    return Err("Resize hasn't been implemented yet!".into());
+    // Create a new command for pfilt
+    let mut command = Command::new(config_settings.radiance_path.to_string() + "pfilt");
+
+    // Add arguments to pfilt command
+    command.args([
+        "-1",
+        "-x",
+        xdim.as_str(),
+        "-y",
+        ydim.as_str(),
+        input_file.as_str(),
+    ]);
+
+    // Direct command's output to specifed output file
+    let file = File::create(&output_file).unwrap();
+    let stdio = Stdio::from(file);
+    command.stdout(stdio);
+
+    // Run the command
+    let status = command.status().unwrap();
+
+    if DEBUG {
+        println!("\nCrop command exit status: {:?}\n", status);
+    }
+
+    // Return a Result object to indicate whether command was successful
+    if status.success() {
+        // On success, return output path of HDR image
+        Ok(output_file.into())
+    } else {
+        // On error, return an error message
+        Err("Error, non-zero exit status. Resize command (pfilt) failed.".into())
+    }
 }


### PR DESCRIPTION
Implements steps 3 and 4 of the pipeline in the backend: cropping and resizing the HDR image.

### *Note:*
Similarly to the other pull requests, to run this successfully, you'll need to change the `_FAKE_RADIANCE_PATH` to match the location of the radiance binaries on your system.

You also need to uncomment `main.rs:31` to `41` where indicated to run the hardcoded version since the integration with the frontend has not been completed yet.

And you'll need to either:
- create a *tmp/* directory inside the repo's directory, or
- change the `_fake_temp_path` to somewhere else to store the images

Additionally, the HDR image produced after nullifying the exposure value (named *output2.hdr*, from the ra_xyze step) will need to be in the *tmp* folder already, otherwise the command will fail. 

Currently, the `_fake_output_path` passed to the pipeline is not used. Since these steps of the pipeline should be occurring in the middle, I thought I'd leave it writing the file to *tmp/*. Can be changed later.

Cropped HDR image is written to *tmp/output3.hdr* at the base level of the repo's directory.
Resized HDR image is written to *tmp/output4.hdr*.

<br>
<br>


Closes #41
