### PR TITLE
Fixed resize command (xdim and ydim args)

### DIFF
--- a/src-tauri/src/pipeline/resize.rs
+++ b/src-tauri/src/pipeline/resize.rs
@@ -36,9 +36,9 @@ pub fn resize(
     command.args([
         "-1",
         "-x",
-        format!("-{xdim}").as_str(),
+        xdim.as_str(),
         "-y",
-        format!("-{ydim}").as_str(),
+        ydim.as_str(),
         input_file.as_str(),
     ]);
 


### PR DESCRIPTION
Fixed the target dimension arguments in the resize step of the Radiance pipeline. Previously wasn't actually resizing the image correctly. Now, image dimensions show 1000 x 1000 for the example data.


Closes #58