### PR TITLE
Modifications to allow tauri build command

### DIFF
--- a/src-docs/src/content/config.ts
+++ b/src-docs/src/content/config.ts
@@ -1,7 +1,7 @@
-import { defineCollection } from 'astro:content';
-import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
+// import { defineCollection } from 'astro:content';
+// import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
 
-export const collections = {
-	docs: defineCollection({ schema: docsSchema() }),
-	i18n: defineCollection({ type: 'data', schema: i18nSchema() }),
-};
+// export const collections = {
+// 	docs: defineCollection({ schema: docsSchema() }),
+// 	i18n: defineCollection({ type: 'data', schema: i18nSchema() }),
+// };

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,7 @@
         "icons/icon.icns",
         "icons/icon.ico"
       ],
-      "identifier": "com.tauri.dev",
+      "identifier": "hdricalibrationtool",
       "longDescription": "",
       "macOS": {
         "entitlements": null,


### PR DESCRIPTION
Commented out `src-docs/src/content/config.ts` because there's some issue here that was blocking the build. I think we'll need it eventually once we start working on the docs, but I haven't been able to figure out what the issue is.

I also added an app identifier in `tauri.conf.json`, which is required for the app to build.

I believe I should be able to start working on the GH action to build automatically once these changes are there.