### PR TITLE
Several small changes to pipeline and batch processing

### DIFF
--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -167,11 +167,13 @@ pub async fn pipeline(
                 return result;
             }
 
-            let mut output_file_name =  config_settings.output_path.join(Path::new(input_dir).file_name().unwrap());
+            let mut output_file_name = config_settings
+                .output_path
+                .join(Path::new(input_dir).file_name().unwrap());
             output_file_name.set_extension("hdr");
             let copy_result = copy(
                 &config_settings.temp_path.join("output9.hdr"),
-               output_file_name,
+                output_file_name,
             );
             if copy_result.is_err() {
                 return Result::Err(
@@ -200,9 +202,8 @@ pub async fn pipeline(
             return result;
         }
 
-
         // let output_file_name =  config_settings.output_path.join("output_".to_owned() + &time + ".hdr");
-        let output_file_name =  config_settings.output_path.join("output.hdr");
+        let output_file_name = config_settings.output_path.join("output.hdr");
 
         // output_file_name.set_extension("hdr");
         let copy_result = copy(
@@ -210,9 +211,7 @@ pub async fn pipeline(
             output_file_name,
         );
         if copy_result.is_err() {
-            return Result::Err(
-                ("Error copying final hdr image to output directory.").to_string(),
-            );
+            return Result::Err(("Error copying final hdr image to output directory.").to_string());
         }
     }
 
@@ -229,20 +228,16 @@ pub fn get_images_from_dir(input_dir: &String) -> Vec<String> {
         .collect::<Result<Vec<_>, io::Error>>()
         .unwrap();
 
-    // println!("=== ENTRIES: {:?}", entries);
-
-    // TODO: use something different than unwrap to avoid panicking
     let mut input_image_paths: Vec<String> = Vec::new();
     for entry in entries {
-        // TODO: Find a way to check all files in directory are images (e.g. not '.DS_store' which causes error)
-        // if entry.extension().unwrap() == "JPEG"
-        //     || entry.extension().unwrap() == "jpeg"
-        //     || entry.extension().unwrap() == "JPG"
-        //     || entry.extension().unwrap() == "jpg"
-        // {
-        let x = entry.into_os_string().into_string().unwrap();
-        input_image_paths.push(x);
-        // }
+        if entry.extension().unwrap_or_default() == "jpg"
+            || entry.extension().unwrap_or_default() == "JPG"
+            || entry.extension().unwrap_or_default() == "jpeg"
+            || entry.extension().unwrap_or_default() == "JPEG"
+        {
+            let x = entry.into_os_string().into_string().unwrap_or_default();
+            input_image_paths.push(x);
+        }
     }
     input_image_paths
 }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -89,7 +89,13 @@ pub async fn pipeline(
 ) -> Result<String, String> {
     let time = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
 
-    let is_directory = Path::new(&input_images[0]).is_dir();
+
+    let is_directory = if input_images.len() > 0 {
+        Path::new(&input_images[0]).is_dir()
+    }
+    else {
+        false
+    };
 
     if DEBUG {
         println!("Pipeline module called...");
@@ -259,7 +265,7 @@ pub fn process_image_set(
     horizontal_angle: String,
 ) -> Result<String, String> {
     // TODO: Examine a safer way to convert paths to strings that works for non utf-8?
-    let _merge_exposures_result = merge_exposures(
+    let merge_exposures_result = merge_exposures(
         &config_settings,
         input_images,
         response_function,
@@ -271,9 +277,9 @@ pub fn process_image_set(
     );
 
     // If the command to merge exposures encountered an error, abort pipeline
-    // if merge_exposures_result.is_err() {
-    //     return merge_exposures_result;
-    // };
+    if merge_exposures_result.is_err() {
+        return merge_exposures_result;
+    };
 
     // Nullify the exposure value
     let nullify_exposure_result = nullify_exposure_value(

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -89,11 +89,9 @@ pub async fn pipeline(
 ) -> Result<String, String> {
     let time = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
 
-
     let is_directory = if input_images.len() > 0 {
         Path::new(&input_images[0]).is_dir()
-    }
-    else {
+    } else {
         false
     };
 

--- a/src-tauri/src/pipeline/merge_exposures.rs
+++ b/src-tauri/src/pipeline/merge_exposures.rs
@@ -1,7 +1,5 @@
 use crate::pipeline::DEBUG;
-use std::os::unix::process::ExitStatusExt;
 use std::process::{Command, ExitStatus};
-use std::string::ToString;
 
 use super::ConfigSettings;
 
@@ -46,7 +44,7 @@ pub fn merge_exposures(
     command.arg("-g");
 
     // Run the command
-    let status = command.status().unwrap_or(ExitStatus::from_raw(1)); // status = ExitStatus of 1 if failure to unwrap
+    let status: ExitStatus = command.status().unwrap_or(ExitStatus::default()); // status = ExitStatus of 1 if failure to unwrap
 
     if DEBUG {
         println!("\nCommand exit status: {:?}\n", status);

--- a/src-tauri/src/pipeline/merge_exposures.rs
+++ b/src-tauri/src/pipeline/merge_exposures.rs
@@ -1,5 +1,6 @@
 use crate::pipeline::DEBUG;
-use std::process::Command;
+use std::os::unix::process::ExitStatusExt;
+use std::process::{Command, ExitStatus};
 use std::string::ToString;
 
 use super::ConfigSettings;
@@ -44,18 +45,15 @@ pub fn merge_exposures(
     command.arg("-f");
     command.arg("-g");
 
-    
-
-
     // Run the command
-    let status = command.status();
+    let status = command.status().unwrap_or(ExitStatus::from_raw(1));       // status = ExitStatus of 1 if failure to unwrap
 
     if DEBUG {
         println!("\nCommand exit status: {:?}\n", status);
     }
 
     // Return a Result object to indicate whether hdrgen command was successful
-    if status.is_ok() {
+    if status.success() {
         // On success, return output path of HDR image
         Ok(output_path.into())
     } else {

--- a/src-tauri/src/pipeline/merge_exposures.rs
+++ b/src-tauri/src/pipeline/merge_exposures.rs
@@ -46,7 +46,7 @@ pub fn merge_exposures(
     command.arg("-g");
 
     // Run the command
-    let status = command.status().unwrap_or(ExitStatus::from_raw(1));       // status = ExitStatus of 1 if failure to unwrap
+    let status = command.status().unwrap_or(ExitStatus::from_raw(1)); // status = ExitStatus of 1 if failure to unwrap
 
     if DEBUG {
         println!("\nCommand exit status: {:?}\n", status);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import { invoke, convertFileSrc } from "@tauri-apps/api/tauri";
 
 import CroppingResizingViewSettings from "./cropping-resizing-view-settings";
 import Settings from "./settings";
-import { ResponseType } from "@tauri-apps/api/http";
 
 const DEBUG = true;
 
@@ -23,8 +22,7 @@ export default function Home() {
     targetRes: "1000",
   });
 
-  // const [imgDirs, setImgDirs] = useState<any[]>([]);
-  let imgDirs: any | any[] = [];
+  // Represents the value of the checkbox for whether user wants to select directories instead of images
   const [directorySelected, setDirectorySelected] = useState<boolean>(false);
 
   // Holds the file paths for the backend
@@ -81,17 +79,24 @@ export default function Home() {
 
   // Open a file dialog window using the tauri api and update the images array with the results
   async function dialog() {
-    selected = await open({
-      multiple: true,
-      filters: [
-        {
-          name: "Image",
-          extensions: ["jpg", "jpeg", "JPG", "JPEG"],
-        },
-      ],
-    });
+    if (directorySelected == true) {
+      selected = await open({
+        multiple: true,
+        directory: true,
+      });
+    }
+    else {
+      selected = await open({
+        multiple: true,
+        filters: [
+          {
+            name: "Image",
+            extensions: ["jpg", "jpeg", "JPG", "JPEG"],
+          },
+        ],
+      });
+    }
     if (Array.isArray(selected)) {
-      setDirectorySelected(false);
       assets = selected.map((item: any) => convertFileSrc(item));
       setImages(images.concat(assets));
       setDevicePaths(devicePaths.concat(selected));
@@ -100,7 +105,6 @@ export default function Home() {
       // user cancelled the selection
     } else {
       // user selected a single file
-      setDirectorySelected(false);
       assets = [convertFileSrc(selected)];
       setImages(images.concat(assets));
       setDevicePaths(devicePaths.concat([selected]));
@@ -110,34 +114,6 @@ export default function Home() {
       console.log("Dialog function called.");
       console.log("selected: ", selected);
       console.log("assets: ", assets);
-    }
-  }
-
-  async function dialogBatchProcessing() {
-    selected = await open({
-      multiple: true,
-      directory: true,
-    });
-    if (selected === null) {
-      // user cancelled the selection
-    } else if (Array.isArray(selected)) {
-      setDirectorySelected(true);
-      assets = selected.map((item: any) => convertFileSrc(item));
-      setImages(images.concat(assets));
-      setDevicePaths(devicePaths.concat(selected));
-      setAssetPaths(assetPaths.concat(assets));
-    } else {
-      setDirectorySelected(true);
-      assets = [convertFileSrc(selected)];
-      setImages(images.concat(assets));
-      setDevicePaths(devicePaths.concat([selected]));
-      setAssetPaths(assetPaths.concat(assets));
-    }
-    if (DEBUG) {
-      console.log(
-        "directories selected in batch processing dialog: ",
-        selected
-      );
     }
   }
 
@@ -361,18 +337,18 @@ export default function Home() {
           <h2 className="font-bold pt-5" id="image_selection">
             Image Selection
           </h2>
-          <button
-            onClick={dialog}
-            className="bg-gray-300 hover:bg-gray-400 text-gray-700 font-semibold py-1 px-2 border-gray-400 rounded"
-          >
-            Select Files
-          </button>
-          <button
-            onClick={dialogBatchProcessing}
-            className="bg-gray-300 hover:bg-gray-400 text-gray-700 font-semibold py-1 px-2 border-gray-400 rounded"
-          >
-            Select Files for Batch Processing
-          </button>
+          <div className="flex flex-row">
+            <button
+              onClick={dialog}
+              className="bg-gray-300 hover:bg-gray-400 text-gray-700 font-semibold py-1 px-2 border-gray-400 rounded h-fit"
+            >
+              Select Files
+            </button>
+            <div className="flex flex-row items-center space-x-4 pl-20">
+              <input type="checkbox" checked={directorySelected} onChange={() => setDirectorySelected(prev => !prev)} />
+              <label>Select directories</label>
+            </div>
+          </div>
           <div>Image count: {images.length}</div>
           <div className="image-preview flex flex-wrap">
             {images.map((image, index) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -340,9 +340,9 @@ export default function Home() {
           </ul>
         </nav>
         <div className="w-3/4 ml-auto pl-3">
-          {showProgress && progress < 100 && <Progress Progress={progress}/>}
+          {showProgress && progress < 100 && <Progress Progress={progress} />}
           <h1 className="font-bold pt-10">Configuration</h1>
-          
+
           <h2 className="font-bold pt-5" id="image_selection">
             Image Selection
           </h2>
@@ -367,7 +367,10 @@ export default function Home() {
               <div>Directory count: {devicePaths.length}</div>
               <div className="directory-preview flex flex-wrap flex-col">
                 {devicePaths.map((path, index) => (
-                  <div key={index} className="directory-item flex flex-row space-x-3">
+                  <div
+                    key={index}
+                    className="directory-item flex flex-row space-x-3"
+                  >
                     <p>{Paths(path)}</p>
                     <button onClick={() => handleImageDelete(index)}>
                       Delete

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -84,8 +84,7 @@ export default function Home() {
         multiple: true,
         directory: true,
       });
-    }
-    else {
+    } else {
       selected = await open({
         multiple: true,
         filters: [
@@ -345,29 +344,51 @@ export default function Home() {
               Select Files
             </button>
             <div className="flex flex-row items-center space-x-4 pl-20">
-              <input type="checkbox" checked={directorySelected} onChange={() => setDirectorySelected(prev => !prev)} />
+              <input
+                type="checkbox"
+                checked={directorySelected}
+                onChange={() => setDirectorySelected((prev) => !prev)}
+              />
               <label>Select directories</label>
             </div>
           </div>
-          <div>Image count: {images.length}</div>
-          <div className="image-preview flex flex-wrap">
-            {images.map((image, index) => (
-              <div key={index} className="image-item">
-                <div>
-                  <img
-                    src={String(image)}
-                    alt={`Image ${index}`}
-                    width={200}
-                    height={200}
-                  />
-                  <button onClick={() => handleImageDelete(index)}>
-                    Delete
-                  </button>
-                  <div>{image.name}</div>
-                </div>
+          {directorySelected ? (
+            <>
+              <div>Directory count: {devicePaths.length}</div>
+              <div className="directory-preview flex flex-wrap flex-col">
+                {devicePaths.map((path, index) => (
+                  <div key={index} className="directory-item flex flex-row space-x-3">
+                    <p>{Paths(path)}</p>
+                    <button onClick={() => handleImageDelete(index)}>
+                      Delete
+                    </button>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
+            </>
+          ) : (
+            <>
+              <div>Image count: {images.length}</div>
+              <div className="image-preview flex flex-wrap">
+                {images.map((image, index) => (
+                  <div key={index} className="image-item">
+                    <div>
+                      <img
+                        src={String(image)}
+                        alt={`Image ${index}`}
+                        width={200}
+                        height={200}
+                      />
+                      <button onClick={() => handleImageDelete(index)}>
+                        Delete
+                      </button>
+                      <div>{image.name}</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
           <h2 className="font-bold pt-5" id="response">
             Response File
           </h2>


### PR DESCRIPTION
- Updated pipeline to check status of hdrgen command (merging exposures step)
- Pipeline now only gathers image files from input directories and ignores all other files
  - Files like _.DS_Store_ previously created a problem, but wouldn't be visible to users looking at their directory with a GUI
- Switched to one input button for regular or batch processing, with a toggle for switching between the modes
- Displays directory names instead of image previews for batch processing

<br>

Closes radiantlab#64, closes radiantlab#67, closes radiantlab#68, closes radiantlab#69