### PR TITLE
Updating GH workflows to test on PR and publish on push to release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+# This workflow will publish a draft release and tag when a push is made to the release branch.
+
+# Created using https://github.com/tauri-apps/tauri-action/blob/dev/examples/publish-to-auto-release.yml
+
+name: 'publish'
+
+on:
+  push:
+    branches:
+      - release
+
+# This workflow will trigger on each push to the `release` branch to create or update a GitHub release, build your app, and upload the artifacts to the release.
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - platform: 'macos-latest' # for Arm based macs (M1 and above).
+            args: '--target aarch64-apple-darwin'
+          - platform: 'macos-latest' # for Intel based macs.
+            args: '--target x86_64-apple-darwin'
+          - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ''
+          - platform: 'windows-latest'
+            args: ''
+
+    runs-on: ${{ matrix.settings.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
+          targets: ${{ matrix.settings.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.settings.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
+        # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
+
+      - name: install frontend dependencies
+        run: npm install # change this to npm, pnpm or bun depending on which one you use.
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          releaseName: 'App v__VERSION__'
+          releaseBody: 'See the assets to download this version and install.'
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.settings.args }}

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -57,13 +57,23 @@ jobs:
         # releaseDraft: true
         # prerelease: false
 
-      - name: Upload build artifacts
+      - name: Upload build artifact - Ubuntu
+        if: matrix.platform == 'ubuntu-20.04'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-build
-          path: |
-            src-tauri/target/release/bundle/dmg/*.dmg
-            src-tauri/target/release/bundle/deb/*.deb
-            src-tauri/target/release/bundle/msi/*.msi
+          path: src-tauri/target/release/bundle/deb/*.deb
 
+      - name: Upload build artifact - Mac
+        if: matrix.platform == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}-build
+          path: src-tauri/target/release/bundle/dmg/*.dmg
 
+      - name: Upload build artifact - Windows
+        if: matrix.platform == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}-build
+          path: src-tauri/target/release/bundle/msi/*.msi

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -57,23 +57,8 @@ jobs:
         # releaseDraft: true
         # prerelease: false
 
-      - name: Upload build artifact - Ubuntu
-        if: matrix.platform == 'ubuntu-20.04'
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-build
-          path: src-tauri/target/release/bundle/deb/*.deb
-
-      - name: Upload build artifact - Mac
-        if: matrix.platform == 'macos-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.platform }}-build
-          path: src-tauri/target/release/bundle/dmg/*.dmg
-
-      - name: Upload build artifact - Windows
-        if: matrix.platform == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.platform }}-build
-          path: src-tauri/target/release/bundle/msi/*.msi
+          path: src-tauri/target/release/bundle/(dmg|deb|msi)/*.(dmg|deb|msi)

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -1,6 +1,8 @@
 # This workflow builds the app when triggered by a pull request to main and is used for 
 # validation of pull requests. Assets are uploaded upon completion.
 
+# Created using https://github.com/tauri-apps/tauri-action/blob/dev/examples/test-build-only.yml 
+
 name: test-on-pr
 on:
   pull_request:

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -61,4 +61,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-build
-          path: src-tauri/target/release/bundle/(dmg|deb|msi)/*.(dmg|deb|msi)
+          path: |
+            src-tauri/target/release/bundle/dmg/*.dmg
+            src-tauri/target/release/bundle/deb/*.deb
+            src-tauri/target/release/bundle/msi/*.msi
+
+

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -1,9 +1,12 @@
-name: Build
+# This workflow builds the app when triggered by a pull request to main and is used for 
+# validation of pull requests. Assets are uploaded upon completion.
+
+name: test-on-pr
 on:
   pull_request:
     branches:
       - main
-      
+
 jobs:
   build-tauri:
     permissions:
@@ -31,13 +34,13 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: './src-tauri -> target'
+          workspaces: "./src-tauri -> target"
 
       - name: Sync node version and setup cache
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
-          cache: 'npm' # Set this to npm, yarn or pnpm.
+          node-version: "lts/*"
+          cache: "npm" # Set this to npm, yarn or pnpm.
 
       - name: Install frontend dependencies
         # If you don't have `beforeBuildCommand` configured you may want to build your frontend here too.
@@ -48,14 +51,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # with:
-          # tagName: ${{ github.ref_name }} # This only works if your workflow triggers on new tags.
-          # releaseName: 'App Name v__VERSION__' # tauri-action replaces \_\_VERSION\_\_ with the app version.
-          # releaseBody: 'See the assets to download and install this version.'
-          # releaseDraft: true
-          # prerelease: false
+        # tagName: ${{ github.ref_name }} # This only works if your workflow triggers on new tags.
+        # releaseName: 'App Name v__VERSION__' # tauri-action replaces \_\_VERSION\_\_ with the app version.
+        # releaseBody: 'See the assets to download and install this version.'
+        # releaseDraft: true
+        # prerelease: false
 
-      - name: Upload build artifacts
+      - name: Upload build artifact - Ubuntu
+        if: matrix.platform == 'ubuntu-20.04'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-build
-          path: src-tauri/target/release/
+          path: src-tauri/target/release/bundle/deb/*.deb
+
+      - name: Upload build artifact - Mac
+        if: matrix.platform == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}-build
+          path: src-tauri/target/release/bundle/dmg/*.dmg
+
+      - name: Upload build artifact - Windows
+        if: matrix.platform == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}-build
+          path: src-tauri/target/release/bundle/msi/*.msi


### PR DESCRIPTION
Modified existing workflow that tests builds for pull requests to upload only .dmg, .msi, or .deb files.

Created another GH workflow for publishing a release when code is pushed to the `release` branch. Haven't been able to test this workflow since that's not possible from the PR, but it's basically what's in the Tauri action docs, so it should hopefully work. 

<br><br>

Closes radiantlab#76