### PR TITLE
test build workflow now runs on pushing to main

### DIFF
--- a/.github/workflows/test-on-pr-and-push.yml
+++ b/.github/workflows/test-on-pr-and-push.yml
@@ -3,11 +3,15 @@
 
 # Created using https://github.com/tauri-apps/tauri-action/blob/dev/examples/test-build-only.yml 
 
-name: test-on-pr
+name: test-on-pr-and-push
 on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
+
 
 jobs:
   build-tauri:


### PR DESCRIPTION
The test build workflow will now run and create artifacts when we merge pull requests into main so that we have an up-to-date build of our current codebase in main, rather than only builds for each pull request.