### PR TITLE
Bug fix for output path input field + default paths based on OS

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -645,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.3.5",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1726,6 +1726,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "os_info"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+dependencies = [
+ "log",
+ "serde",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,7 +2243,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2560,6 +2571,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a11bd9c338fdba09f7881ab41551932ad42e405f61d01e8406baea71c07aee"
+dependencies = [
+ "js-sys",
+ "libc",
+ "wasm-bindgen",
+ "web-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "system-deps"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2705,7 @@ dependencies = [
  "ignore",
  "objc",
  "once_cell",
+ "os_info",
  "percent-encoding",
  "rand 0.8.5",
  "raw-window-handle",
@@ -2691,6 +2716,7 @@ dependencies = [
  "serde_repr",
  "serialize-to-javascript",
  "state",
+ "sys-locale",
  "tar",
  "tauri-macros",
  "tauri-runtime",
@@ -2855,7 +2881,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.4.1",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3490,11 +3516,44 @@ checksum = "9ee5e275231f07c6e240d14f34e1b635bf1faa1c76c57cfd59a5cdb9848e4278"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3535,6 +3594,12 @@ checksum = "f838de2fe15fe6bac988e74b798f26499a8b21a9d97edec321e79b28d1d7f597"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3556,6 +3621,12 @@ name = "windows_aarch64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3583,6 +3654,12 @@ checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -3604,6 +3681,12 @@ name = "windows_i686_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3631,6 +3714,12 @@ checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -3640,6 +3729,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3664,6 +3759,12 @@ name = "windows_x86_64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3693,7 +3794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "937f3df7948156640f46aacef17a70db0de5917bda9c92b0f751f3a955b588fc"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.5.0", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.5.2", features = [ "app-show", "app-hide", "dialog-all", "protocol-all"] }
+tauri = { version = "1.5.2", features = [ "os-all", "app-show", "app-hide", "dialog-all", "protocol-all"] }
 chrono = "0.4.33"
 
 [features]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,6 +5,10 @@
 mod pipeline;
 use pipeline::pipeline;
 
+// Command to query operating system from frontend
+mod query_os_platform;
+use query_os_platform::query_os_platform;
+
 use std::env;
 
 // Hardcoded radiance and hdrgen paths for backend testing
@@ -101,7 +105,7 @@ fn main() {
 
 
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![pipeline])
+        .invoke_handler(tauri::generate_handler![pipeline, query_os_platform])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/query_os_platform.rs
+++ b/src-tauri/src/query_os_platform.rs
@@ -1,0 +1,9 @@
+use std::env;
+
+// Returns a string representing the OS platform. Used for configuring default paths 
+// for binaries on frontend.
+#[tauri::command]
+pub async fn query_os_platform() -> String {
+    let platform = env::consts::OS;
+    return platform.to_string();
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,20 +13,21 @@
   "tauri": {
     "allowlist": {
       "all": false,
+      "os": {
+        "all": true
+      },
       "dialog": {
-        "all": true, 
-        "ask": true, 
-        "confirm": true, 
-        "message": true, 
+        "all": true,
+        "ask": true,
+        "confirm": true,
+        "message": true,
         "open": true,
         "save": true
       },
       "protocol": {
         "all": true,
         "asset": true,
-        "assetScope": [
-          "**"
-        ]
+        "assetScope": ["**"]
       },
       "app": {
         "show": true,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,12 +10,42 @@ import { ResponseType } from "@tauri-apps/api/http";
 import SaveConfigDialog from "./save-config-dialog";
 import { getName, getTauriVersion, getVersion } from "@tauri-apps/api/app";
 import LoadConfigDialog from "./load-config-dialog";
+import { type } from "@tauri-apps/api/os";
 
 const DEBUG = true;
 
 const fakePipeline = false;
 
 export default function Home() {
+
+  // Updates radiance, hdrgen, and raw2hdr paths in settings to match default os type
+  async function getDefaultPath() {
+    const osType = await type()
+
+    // Default path for Linux or Mac is /usr/local/bin
+    let defaultPath = "/usr/local/bin"
+
+    // If Windows, update default path
+    if (osType == "Windows_NT") {
+      defaultPath = "C:\\bin"
+    }
+
+    let updatedSettings = {
+      radiancePath: defaultPath,
+      hdrgenPath: defaultPath,
+      raw2hdrPath: defaultPath,
+      outputPath: settings.outputPath,
+    }
+    setSettings(updatedSettings)
+  }
+
+  // Get the default paths for the os
+  useEffect(() => {
+    getDefaultPath()
+  }, [])
+
+
+
   // Holds the fisheye coordinates and view settings
   const [viewSettings, setViewSettings] = useState({
     // xres: "",
@@ -76,9 +106,15 @@ export default function Home() {
     useState<boolean>(false);
 
   const [settings, setSettings] = useState({
-    radiancePath: "/usr/local/radiance/bin/",
-    hdrgenPath: "/usr/local/bin/",
-    raw2hdrPath: "/usr/local/bin/",
+    // radiancePath: defaultPath,
+    // hdrgenPath: defaultPath,
+    // raw2hdrPath: defaultPath,
+    radiancePath: "",
+    hdrgenPath: "",
+    raw2hdrPath: "",
+    // radiancePath: "/usr/local/radiance/bin/",
+    // hdrgenPath: "/usr/local/bin/",
+    // raw2hdrPath: "/usr/local/bin/",
     outputPath: "/home/hdri-app/",
   });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,41 +10,43 @@ import { ResponseType } from "@tauri-apps/api/http";
 import SaveConfigDialog from "./save-config-dialog";
 import { getName, getTauriVersion, getVersion } from "@tauri-apps/api/app";
 import LoadConfigDialog from "./load-config-dialog";
-import { type } from "@tauri-apps/api/os";
 
 const DEBUG = true;
 
 const fakePipeline = false;
 
 export default function Home() {
-
-  // Updates radiance, hdrgen, and raw2hdr paths in settings to match default os type
-  async function getDefaultPath() {
-    const osType = await type()
-
-    // Default path for Linux or Mac is /usr/local/bin
-    let defaultPath = "/usr/local/bin"
-
-    // If Windows, update default path
-    if (osType == "Windows_NT") {
-      defaultPath = "C:\\bin"
-    }
-
-    let updatedSettings = {
-      radiancePath: defaultPath,
-      hdrgenPath: defaultPath,
-      raw2hdrPath: defaultPath,
-      outputPath: settings.outputPath,
-    }
-    setSettings(updatedSettings)
-  }
-
-  // Get the default paths for the os
+  // Get default binary paths to populate settings fields based on OS
   useEffect(() => {
-    getDefaultPath()
-  }, [])
+    let osPlatform = "";
 
+    // Make a call to the backend to get OS platform
+    invoke<string>("query_os_platform", {})
+      .then((platform: any) => {
+        if (DEBUG) {
+          console.log("OS platform successfully queried:", platform);
+        }
 
+        // Default path for macOS and Linux
+        let defaultPath = "/usr/local/bin";
+
+        // If platform is windows, update default path
+        if (osPlatform === "windows") {
+          defaultPath = "C:\\bin";
+        }
+
+        // Update settings
+        setSettings({
+          radiancePath: defaultPath,
+          hdrgenPath: defaultPath,
+          raw2hdrPath: defaultPath,
+          outputPath: settings.outputPath,
+        });
+      })
+      .catch(() => {
+        console.error;
+      });
+  }, []);
 
   // Holds the fisheye coordinates and view settings
   const [viewSettings, setViewSettings] = useState({
@@ -106,15 +108,9 @@ export default function Home() {
     useState<boolean>(false);
 
   const [settings, setSettings] = useState({
-    // radiancePath: defaultPath,
-    // hdrgenPath: defaultPath,
-    // raw2hdrPath: defaultPath,
     radiancePath: "",
     hdrgenPath: "",
     raw2hdrPath: "",
-    // radiancePath: "/usr/local/radiance/bin/",
-    // hdrgenPath: "/usr/local/bin/",
-    // raw2hdrPath: "/usr/local/bin/",
     outputPath: "/home/hdri-app/",
   });
 

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -113,7 +113,7 @@ export default function Settings({
                           name="outputPathTextbox"
                           type="text"
                           value={settings.outputPath}
-                          onChange={handleChange}
+                          onChange={(e) => handleUpdateOutputPath(e.target.value)}
                           className="placeholder:text-right w-full shadow appearance-none border border-gray-400 rounded py-2 px-3 leading-tight focus:outline-none focus:shadow-outline"
                         ></input>
                       </div>


### PR DESCRIPTION
I fixed a bug for the output path input field related to React state. Previously, the text input option wouldn't allow the user to change the input and they had to use the file dialog button. Now, both text input and file dialog options for entering the output directory should work correctly.

I also added code to check for the OS type using a Tauri command (Tauri API call was not working because it used a deprecated method) and update the default paths to radiance, hdrgen, and raw2hdr based on that. However I'm not sure what the different default paths should be for the different operating systems, so I might need to update those. For now, I put my best guess on what those should be:
- macOS and Linux: `/usr/local/bin` for all three CLAs
- Windows: `C:\bin`

<br><br>

Closes radiantlab#89