### PR TITLE
Updated test-on-pr-and-push to fix build issue

### DIFF
--- a/.github/workflows/test-on-pr-and-push.yml
+++ b/.github/workflows/test-on-pr-and-push.yml
@@ -72,7 +72,7 @@ jobs:
         if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.platform }}-build
+          name: ${{ matrix.platform }}-${{ matrix.args }}-build
           path: src-tauri/target/release/bundle/dmg/*.dmg
 
       - name: Upload build artifact - Windows

--- a/.github/workflows/test-on-pr-and-push.yml
+++ b/.github/workflows/test-on-pr-and-push.yml
@@ -1,7 +1,7 @@
-# This workflow builds the app when triggered by a pull request to main and is used for 
+# This workflow builds the app when triggered by a pull request to main and is used for
 # validation of pull requests. Assets are uploaded upon completion.
 
-# Created using https://github.com/tauri-apps/tauri-action/blob/dev/examples/test-build-only.yml 
+# Created using https://github.com/tauri-apps/tauri-action/blob/dev/examples/test-build-only.yml
 
 name: test-on-pr-and-push
 on:
@@ -12,59 +12,57 @@ on:
     branches:
       - main
 
+# This workflow will build your tauri app without uploading it anywhere.
 
 jobs:
-  build-tauri:
-    permissions:
-      contents: write
+  test-tauri:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-20.04, windows-latest]
+        include:
+          - platform: "macos-latest" # for Arm based macs (M1 and above).
+            args: "--target aarch64-apple-darwin"
+          - platform: "macos-latest" # for Intel based macs.
+            args: "--target x86_64-apple-darwin"
+          - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ""
+          - platform: "windows-latest"
+            args: ""
+
     runs-on: ${{ matrix.platform }}
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-20.04'
-        # You can remove libayatana-appindicator3-dev if you don't use the system tray feature.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev
-
-      - name: Rust setup
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Rust cache
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: "./src-tauri -> target"
-
-      - name: Sync node version and setup cache
+      - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
-          cache: "npm" # Set this to npm, yarn or pnpm.
+          node-version: lts/*
 
-      - name: Install frontend dependencies
-        # If you don't have `beforeBuildCommand` configured you may want to build your frontend here too.
-        run: npm install # Change this to npm, yarn or pnpm.
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
-      - name: Build the app
-        uses: tauri-apps/tauri-action@v0
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+        # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
+        # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
+
+      - name: install frontend dependencies
+        run: yarn install # change this to npm, pnpm or bun depending on which one you use.
+
+      # If tagName and releaseId are omitted tauri-action will only build the app and won't try to upload any asstes.
+      - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # with:
-        # tagName: ${{ github.ref_name }} # This only works if your workflow triggers on new tags.
-        # releaseName: 'App Name v__VERSION__' # tauri-action replaces \_\_VERSION\_\_ with the app version.
-        # releaseBody: 'See the assets to download and install this version.'
-        # releaseDraft: true
-        # prerelease: false
+          args: ${{ matrix.args }}
 
       - name: Upload build artifact - Ubuntu
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-build

--- a/.github/workflows/test-on-pr-and-push.yml
+++ b/.github/workflows/test-on-pr-and-push.yml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: "macos-latest" # for Arm based macs (M1 and above).
-            args: "--target aarch64-apple-darwin"
+          # - platform: "macos-latest" # for Arm based macs (M1 and above).
+          #   args: "--target aarch64-apple-darwin"
           - platform: "macos-latest" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
           - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.

--- a/.github/workflows/test-on-pr-and-push.yml
+++ b/.github/workflows/test-on-pr-and-push.yml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - platform: "macos-latest" # for Arm based macs (M1 and above).
-          #   args: "--target aarch64-apple-darwin"
+          - platform: "macos-latest" # for Arm based macs (M1 and above).
+            args: "--target aarch64-apple-darwin"
           - platform: "macos-13" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
           - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
@@ -42,7 +42,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
-          targets: ${{ matrix.platform == 'macos-13' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ (matrix.platform == 'macos-13' || matrix.platform == 'macos-latest') && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
@@ -75,12 +75,12 @@ jobs:
           name: ${{ matrix.platform }}-x86-build
           path: src-tauri/target/release/bundle/dmg/*.dmg
 
-      # - name: Upload build artifact - Mac (Arm)
-      #   if: matrix.platform == 'macos-latest'
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: ${{ matrix.platform }}-aarch64-build
-      #     path: src-tauri/target/release/bundle/dmg/*.dmg
+      - name: Upload build artifact - Mac (Arm)
+        if: matrix.platform == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}-aarch64-build
+          path: src-tauri/target/release/bundle/dmg/*.dmg
 
       - name: Upload build artifact - Windows
         if: matrix.platform == 'windows-latest'

--- a/.github/workflows/test-on-pr-and-push.yml
+++ b/.github/workflows/test-on-pr-and-push.yml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: "macos-latest" # for Arm based macs (M1 and above).
-            args: "--target aarch64-apple-darwin"
+          # - platform: "macos-latest" # for Arm based macs (M1 and above).
+          #   args: "--target aarch64-apple-darwin"
           - platform: "macos-13" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
           - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
@@ -42,7 +42,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
-          targets: ${{ matrix.platform == 'macos-13' || matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.platform == 'macos-13' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
@@ -75,12 +75,12 @@ jobs:
           name: ${{ matrix.platform }}-x86-build
           path: src-tauri/target/release/bundle/dmg/*.dmg
 
-      - name: Upload build artifact - Mac (Arm)
-        if: matrix.platform == 'macos-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.platform }}-aarch64-build
-          path: src-tauri/target/release/bundle/dmg/*.dmg
+      # - name: Upload build artifact - Mac (Arm)
+      #   if: matrix.platform == 'macos-latest'
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: ${{ matrix.platform }}-aarch64-build
+      #     path: src-tauri/target/release/bundle/dmg/*.dmg
 
       - name: Upload build artifact - Windows
         if: matrix.platform == 'windows-latest'

--- a/.github/workflows/test-on-pr-and-push.yml
+++ b/.github/workflows/test-on-pr-and-push.yml
@@ -53,7 +53,7 @@ jobs:
         # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
 
       - name: install frontend dependencies
-        run: yarn install # change this to npm, pnpm or bun depending on which one you use.
+        run: npm install # change this to npm, pnpm or bun depending on which one you use.
 
       # If tagName and releaseId are omitted tauri-action will only build the app and won't try to upload any asstes.
       - uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/test-on-pr-and-push.yml
+++ b/.github/workflows/test-on-pr-and-push.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - platform: "macos-latest" # for Arm based macs (M1 and above).
-          #   args: "--target aarch64-apple-darwin"
-          - platform: "macos-latest" # for Intel based macs.
+          - platform: "macos-latest" # for Arm based macs (M1 and above).
+            args: "--target aarch64-apple-darwin"
+          - platform: "macos-13" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
           - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
             args: ""
@@ -42,7 +42,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.platform == 'macos-13' || matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
@@ -68,11 +68,18 @@ jobs:
           name: ${{ matrix.platform }}-build
           path: src-tauri/target/release/bundle/deb/*.deb
 
-      - name: Upload build artifact - Mac
+      - name: Upload build artifact - Mac (Intel)
+        if: matrix.platform == 'macos-13'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}-x86-build
+          path: src-tauri/target/release/bundle/dmg/*.dmg
+
+      - name: Upload build artifact - Mac (Arm)
         if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.platform }}-${{ matrix.args }}-build
+          name: ${{ matrix.platform }}-aarch64-build
           path: src-tauri/target/release/bundle/dmg/*.dmg
 
       - name: Upload build artifact - Windows


### PR DESCRIPTION
It appears GH's new M1 runners (which is used if you specify `macos-latest`) was causing some sort of issue with the Tauri action, and x86 builds were not being created.

I updated the test workflow according to the new example on the Tauri Actions GH page. However, this still was not working for me and would only create two builds for ARM-based Macs.

To fix this for now, I figured out I could switch to the `macos-13` runner which is Intel-based, although the build time is longer than using the new M1 GH runner. The `macos-latest` runner (M1) is still used for the ARM-based build.

I don't know if we need to update the publish workflow, but if it becomes evident we do, we can probably do something similar and use this workflow as a guide.

Hopefully everything works – the x86 build looks correct to me – but I can't easily test the others and I'm not really familar with GH actions, so it's entirely possible it'll become clear something else is wrong.

<br> <br>

Closes radiantlab#92

