### PR TITLE
Issue96

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.5.0", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.5.2", features = [ "path-all", "os-all", "app-show", "app-hide", "dialog-all", "protocol-all"] }
+tauri = { version = "1.5.2", features = [ "fs-read-file", "fs-write-file", "path-all", "os-all", "app-show", "app-hide", "dialog-all", "protocol-all"] }
 chrono = "0.4.33"
 
 [features]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.5.0", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.5.2", features = [ "os-all", "app-show", "app-hide", "dialog-all", "protocol-all"] }
+tauri = { version = "1.5.2", features = [ "path-all", "os-all", "app-show", "app-hide", "dialog-all", "protocol-all"] }
 chrono = "0.4.33"
 
 [features]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.5.0", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.5.2", features = [ "fs-exists", "fs-read-file", "fs-write-file", "path-all", "os-all", "app-show", "app-hide", "dialog-all", "protocol-all"] }
+tauri = { version = "1.5.2", features = [ "fs-read-dir", "fs-copy-file", "fs-create-dir", "fs-exists", "fs-read-file", "fs-write-file", "path-all", "os-all", "app-show", "app-hide", "dialog-all", "protocol-all"] }
 chrono = "0.4.33"
 
 [features]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.5.0", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.5.2", features = [ "fs-read-file", "fs-write-file", "path-all", "os-all", "app-show", "app-hide", "dialog-all", "protocol-all"] }
+tauri = { version = "1.5.2", features = [ "fs-exists", "fs-read-file", "fs-write-file", "path-all", "os-all", "app-show", "app-hide", "dialog-all", "protocol-all"] }
 chrono = "0.4.33"
 
 [features]

--- a/src-tauri/src/get_default_output_path.rs
+++ b/src-tauri/src/get_default_output_path.rs
@@ -1,0 +1,9 @@
+#[tauri::command]
+pub async fn get_default_output_path(app_handle: tauri::AppHandle) -> String {
+    // Retrieved part of this code from https://github.com/tauri-apps/tauri/discussions/5557
+    let binding_result = app_handle.path_resolver().app_data_dir();
+    match binding_result {
+        Some(v) => v.to_string_lossy().to_string(),
+        None => "".to_string(),
+    }
+}

--- a/src-tauri/src/get_saved_configs.rs
+++ b/src-tauri/src/get_saved_configs.rs
@@ -1,0 +1,149 @@
+use std::{
+    fs::{self, read_to_string},
+    io,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{from_str, to_string};
+
+#[derive(Serialize, Deserialize)]
+struct Config {
+    name: String,
+    response_paths: String,
+    fe_correction_paths: String,
+    v_correction_paths: String,
+    nd_correction_paths: String,
+    cf_correction_paths: String,
+    diameter: String,
+    xleft: String,
+    ydown: String,
+    target_res: String,
+    vh: String,
+    vv: String,
+}
+
+#[derive(Serialize)]
+struct SavedConfigs {
+    configurations: Vec<Config>,
+}
+
+#[tauri::command]
+pub async fn get_saved_configs(app_handle: tauri::AppHandle) -> Result<String, String> {
+    let mut saved_configs = SavedConfigs {
+        configurations: vec![],
+    };
+
+    // Retrieved part of this code from https://github.com/tauri-apps/tauri/discussions/5557
+    let binding_result = app_handle.path_resolver().app_config_dir();
+    let binding = match binding_result {
+        Some(v) => v,
+        None => return Err("Error getting saved configs".to_string()),
+    };
+
+    // Get suggested config directory for the app from Tauri
+    let app_config_dir_result = binding.to_str();
+    let app_config_dir = match app_config_dir_result {
+        Some(v) => v,
+        None => return Err("Error getting saved configs".to_string()),
+    };
+
+    let dir = Path::new(app_config_dir).join("configurations");
+
+    if !dir.exists() {
+        return match to_string(&saved_configs) {
+            Ok(v) => Ok(v.to_string()),
+            Err(_) => {
+                return Err("Error getting saved configs: Could not convert to JSON.".to_string())
+            }
+        };
+    }
+
+    // Get everything in the configurations dir
+    let dir_contents = match fs::read_dir(dir) {
+        Ok(v) => match v
+            .map(|res| res.map(|e| e.path()))
+            .collect::<Result<Vec<_>, io::Error>>()
+        {
+            Ok(entry) => entry,
+            Err(_) => return Err("Error getting saved configs".to_string()),
+        },
+        Err(_) => return Err("Error getting saved configs".to_string()),
+    };
+
+    for entry in dir_contents {
+        match process_configuration(entry) {
+            Some(config) => saved_configs.configurations.push(config),
+            None => (), // Error occured reading directory (may not be valid configuration), skip it
+        };
+    }
+
+    let saved_configs_json = match to_string(&saved_configs) {
+        Ok(v) => v,
+        Err(_) => return Err("Error getting saved configs: Could not convert to JSON.".to_string()),
+    };
+
+    return Ok(saved_configs_json.to_string());
+}
+
+fn process_configuration(dir: PathBuf) -> Option<Config> {
+    let config_info = match read_to_string(dir.join("configuration.json")) {
+        Ok(v) => v,
+        Err(_) => return None,
+    };
+
+    let mut config_obj: Config = match from_str(&config_info) {
+        Ok(v) => v,
+        Err(_) => return None,
+    };
+
+    if config_obj.response_paths != "" {
+        config_obj.response_paths = dir
+            .join(config_obj.response_paths)
+            .to_string_lossy()
+            .to_string();
+        if !Path::new(&config_obj.response_paths).exists() {
+            return None;
+        }
+    }
+
+    if config_obj.fe_correction_paths != "" {
+        config_obj.fe_correction_paths = dir
+            .join(config_obj.fe_correction_paths)
+            .to_string_lossy()
+            .to_string();
+        if !Path::new(&config_obj.fe_correction_paths).exists() {
+            return None;
+        }
+    }
+
+    if config_obj.v_correction_paths != "" {
+        config_obj.v_correction_paths = dir
+            .join(config_obj.v_correction_paths)
+            .to_string_lossy()
+            .to_string();
+        if !Path::new(&config_obj.v_correction_paths).exists() {
+            return None;
+        }
+    }
+    if config_obj.nd_correction_paths != "" {
+        config_obj.nd_correction_paths = dir
+            .join(config_obj.nd_correction_paths)
+            .to_string_lossy()
+            .to_string();
+        if !Path::new(&config_obj.nd_correction_paths).exists() {
+            return None;
+        }
+    }
+    if config_obj.cf_correction_paths != "" {
+        config_obj.cf_correction_paths = dir
+            .join(config_obj.cf_correction_paths)
+            .to_string_lossy()
+            .to_string();
+        if !Path::new(&config_obj.cf_correction_paths).exists() {
+            return None;
+        }
+    }
+
+    return Some(config_obj);
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,6 +17,10 @@ use get_default_output_path::get_default_output_path;
 mod save_config;
 use save_config::save_config;
 
+// Command to retrieve saved configurations
+mod get_saved_configs;
+use get_saved_configs::get_saved_configs;
+
 use std::env;
 
 // Hardcoded radiance and hdrgen paths for backend testing
@@ -117,7 +121,8 @@ fn main() {
             pipeline, 
             query_os_platform, 
             get_default_output_path, 
-            save_config
+            save_config,
+            get_saved_configs
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,14 @@ use pipeline::pipeline;
 mod query_os_platform;
 use query_os_platform::query_os_platform;
 
+// Command to get app's data directory
+mod get_default_output_path;
+use get_default_output_path::get_default_output_path;
+
+// Command to save configuration
+mod save_config;
+use save_config::save_config;
+
 use std::env;
 
 // Hardcoded radiance and hdrgen paths for backend testing
@@ -105,7 +113,12 @@ fn main() {
 
 
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![pipeline, query_os_platform])
+        .invoke_handler(tauri::generate_handler![
+            pipeline, 
+            query_os_platform, 
+            get_default_output_path, 
+            save_config
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/save_config.rs
+++ b/src-tauri/src/save_config.rs
@@ -1,0 +1,124 @@
+use std::{
+    fs::{copy, create_dir_all, write},
+    path::Path,
+};
+
+use serde::Serialize;
+use serde_json::to_string;
+
+#[derive(Serialize)]
+struct Config {
+    name: String,
+    response_paths: String,
+    fe_correction_paths: String,
+    v_correction_paths: String,
+    nd_correction_paths: String,
+    cf_correction_paths: String,
+    diameter: String,
+    xleft: String,
+    ydown: String,
+    target_res: String,
+    vh: String,
+    vv: String,
+}
+
+#[tauri::command]
+pub async fn save_config(
+    app_handle: tauri::AppHandle,
+    name: String,
+    response_paths: String,
+    fe_correction_paths: String,
+    v_correction_paths: String,
+    nd_correction_paths: String,
+    cf_correction_paths: String,
+    diameter: String,
+    xleft: String,
+    ydown: String,
+    target_res: String,
+    vh: String,
+    vv: String,
+) -> Result<String, String> {
+    let mut config = Config {
+        name,
+        response_paths,
+        fe_correction_paths,
+        v_correction_paths,
+        nd_correction_paths,
+        cf_correction_paths,
+        diameter,
+        xleft,
+        ydown,
+        target_res,
+        vh,
+        vv,
+    };
+
+    // Retrieved part of this code from https://github.com/tauri-apps/tauri/discussions/5557
+    let binding_result = app_handle.path_resolver().app_config_dir();
+    let binding = match binding_result {
+        Some(v) => v,
+        None => return Err("Error saving config".to_string()),
+    };
+
+    // Get suggested config directory for the app from Tauri
+    let app_config_dir_result = binding.to_str();
+    let app_config_dir = match app_config_dir_result {
+        Some(v) => v,
+        None => return Err("Error saving config".to_string()),
+    };
+
+    println!("\n\n\n\nAPP CONFIG DIR: {app_config_dir}\n\n\n\n");
+
+    let dir = Path::new(app_config_dir)
+        .join("configurations")
+        .join(&config.name);
+    if create_dir_all(&dir).is_err() {
+        return Err("Error saving config.".to_string());
+    }
+
+    let mut is_error = false;
+    if config.response_paths != "" {
+        is_error =
+            is_error || copy(&config.response_paths, &dir.join("responseFunction.rsp")).is_err();
+        config.response_paths = "responseFunction.rsp".to_string();
+    };
+
+    if config.fe_correction_paths != "" {
+        is_error =
+            is_error || copy(&config.fe_correction_paths, &dir.join("fe_correction.cal")).is_err();
+        config.fe_correction_paths = "fe_correction.cal".to_string();
+    };
+
+    if config.v_correction_paths != "" {
+        is_error =
+            is_error || copy(&config.v_correction_paths, &dir.join("v_correction.cal")).is_err();
+        config.v_correction_paths = "v_correction.cal".to_string();
+    };
+
+    if config.nd_correction_paths != "" {
+        is_error =
+            is_error || copy(&config.nd_correction_paths, &dir.join("nd_correction.cal")).is_err();
+        config.nd_correction_paths = "nd_correction.cal".to_string();
+    };
+
+    if config.cf_correction_paths != "" {
+        is_error =
+            is_error || copy(&config.cf_correction_paths, &dir.join("cf_correction.cal")).is_err();
+        config.cf_correction_paths = "cf_correction.cal".to_string();
+    };
+
+    let json = match to_string(&config) {
+        Ok(v) => v,
+        Err(_) => return Err("Error saving config: Could not convert to JSON.".to_string()),
+    };
+
+    is_error = is_error || write(&dir.join("configuration.json"), json).is_err();
+
+    if is_error {
+        return Err("Error saving config.".to_string());
+    }
+
+    Ok(format!(
+        "Successfully saved configuration to {app_config_dir}"
+    ))
+}

--- a/src-tauri/src/save_config.rs
+++ b/src-tauri/src/save_config.rs
@@ -22,7 +22,7 @@ struct Config {
     vv: String,
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn save_config(
     app_handle: tauri::AppHandle,
     name: String,
@@ -67,8 +67,6 @@ pub async fn save_config(
         None => return Err("Error saving config".to_string()),
     };
 
-    println!("\n\n\n\nAPP CONFIG DIR: {app_config_dir}\n\n\n\n");
-
     let dir = Path::new(app_config_dir)
         .join("configurations")
         .join(&config.name);
@@ -79,8 +77,8 @@ pub async fn save_config(
     let mut is_error = false;
     if config.response_paths != "" {
         is_error =
-            is_error || copy(&config.response_paths, &dir.join("responseFunction.rsp")).is_err();
-        config.response_paths = "responseFunction.rsp".to_string();
+            is_error || copy(&config.response_paths, &dir.join("response_function.rsp")).is_err();
+        config.response_paths = "response_function.rsp".to_string();
     };
 
     if config.fe_correction_paths != "" {
@@ -119,6 +117,7 @@ pub async fn save_config(
     }
 
     Ok(format!(
-        "Successfully saved configuration to {app_config_dir}"
+        "Successfully saved configuration to {}",
+        dir.display()
     ))
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,6 +13,9 @@
   "tauri": {
     "allowlist": {
       "all": false,
+      "path": {
+        "all": true
+      },
       "os": {
         "all": true
       },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,10 @@
       "fs": {
         "writeFile": true,
         "readFile": true,
+        "copyFile": true,
+        "createDir": true,
         "exists": true,
+        "readDir": true,
         "scope": ["**"]
       },
       "os": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,6 +19,7 @@
       "fs": {
         "writeFile": true,
         "readFile": true,
+        "exists": true,
         "scope": ["**"]
       },
       "os": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,6 +16,11 @@
       "path": {
         "all": true
       },
+      "fs": {
+        "writeFile": true,
+        "readFile": true,
+        "scope": ["**"]
+      },
       "os": {
         "all": true
       },

--- a/src/app/load-config-dialog.tsx
+++ b/src/app/load-config-dialog.tsx
@@ -1,13 +1,22 @@
 import { useEffect, useState } from "react";
 
 // Modal used for loading a saved configuration
-export default function LoadConfigDialog({ setConfig, savedConfigs, toggleDialog }: any) {
+export default function LoadConfigDialog({
+  setConfig,
+  savedConfigs,
+  getSavedConfigs,
+  toggleDialog,
+}: any) {
   const defaultSelectMessage = "-- select a configuration --";
 
   const [configName, setConfigName] = useState<string>(defaultSelectMessage);
   const [showError, setShowError] = useState<boolean>(false);
 
-  // // Loads configuration to localStorage with the specified name
+  useEffect(() => {
+    getSavedConfigs();
+  }, []);
+
+  // Loads configuration with the specified name
   function handleLoadConfig() {
     // If the user did not make a choice and left default option selected, show error
     if (configName == defaultSelectMessage) {

--- a/src/app/load-config-dialog.tsx
+++ b/src/app/load-config-dialog.tsx
@@ -64,7 +64,6 @@ export default function LoadConfigDialog({ setConfig, savedConfigs, toggleDialog
                     onChange={(e) => {
                       setConfigName(e.target.value);
                     }}
-                    defaultValue={defaultSelectMessage}
                   >
                     <option value={defaultSelectMessage}>
                       {defaultSelectMessage}

--- a/src/app/load-config-dialog.tsx
+++ b/src/app/load-config-dialog.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 
 // Modal used for loading a saved configuration
-export default function LoadConfigDialog({ setConfig, toggleDialog }: any) {
-  const defaultSelectMessage = "-- select a config --";
+export default function LoadConfigDialog({ setConfig, savedConfigs, toggleDialog }: any) {
+  const defaultSelectMessage = "-- select a configuration --";
 
   const [configName, setConfigName] = useState<string>(defaultSelectMessage);
   const [showError, setShowError] = useState<boolean>(false);
@@ -32,11 +32,6 @@ export default function LoadConfigDialog({ setConfig, toggleDialog }: any) {
     // setShowError(false);
     toggleDialog();
   }
-
-  const [savedConfigs, setSavedConfigs] = useState<any>([]);
-  useEffect(() => {
-    setSavedConfigs(JSON.parse(localStorage.getItem("configs") || "[]"));
-  }, []);
 
   return (
     <>

--- a/src/app/navigation.tsx
+++ b/src/app/navigation.tsx
@@ -4,8 +4,6 @@ import SaveConfigDialog from "./save-config-dialog"
 import LoadConfigDialog from "./load-config-dialog"
 import Settings from "./settings"
 import { getName, getTauriVersion, getVersion } from "@tauri-apps/api/app";
-import { appConfigDir, join } from "@tauri-apps/api/path"
-import { exists, readTextFile } from "@tauri-apps/api/fs"
 
 export default function Navigation({
     responsePaths,
@@ -34,8 +32,7 @@ export default function Navigation({
     const [appVersion, setAppVersion] = useState<string>("");
     const [appName, setAppName] = useState<string>("");
     const [tauriVersion, setTauriVersion] = useState<string>("");
-    const [configFilePath, setConfigFilePath] = useState<string>("")
-    const [savedConfigs, setSavedConfigs] = useState<[]>()
+    const [savedConfigs, setSavedConfigs] = useState<[]>([]);
 
     // Retrieves app name, app version, and tauri version from Tauri API
     useEffect(() => {
@@ -45,18 +42,7 @@ export default function Navigation({
         setTauriVersion(await getTauriVersion());
         }
 
-        async function getSavedConfigs() {
-            let configFile = await join(await appConfigDir(), "configurations.json");
-            let configFileData = []
-            if (await exists(configFile)) {
-                configFileData = JSON.parse(await readTextFile(configFile))
-            }
-            setConfigFilePath(configFile)
-            setSavedConfigs(configFileData)
-        }
-
         fetchAppInfo();
-        getSavedConfigs();
     }, []);
     return(
         <div>
@@ -103,10 +89,10 @@ export default function Navigation({
                         <SaveConfigDialog
                         config={{
                             responsePaths: responsePaths,
-                            fe_correctionPaths: fe_correctionPaths,
-                            v_correctionPaths: v_correctionPaths,
-                            nd_correctionPaths: nd_correctionPaths,
-                            cf_correctionPaths: cf_correctionPaths,
+                            feCorrectionPaths: fe_correctionPaths,
+                            vCorrectionPaths: v_correctionPaths,
+                            ndCorrectionPaths: nd_correctionPaths,
+                            cfCorrectionPaths: cf_correctionPaths,
                             diameter: viewSettings.diameter,
                             xleft: viewSettings.xleft,
                             ydown: viewSettings.ydown,
@@ -116,7 +102,6 @@ export default function Navigation({
                             vh: viewSettings.vh,
                             vv: viewSettings.vv,
                         }}
-                        configFilePath={configFilePath}
                         savedConfigs={savedConfigs}
                         toggleDialog={() =>
                             setShowSaveConfigDialog(!showSaveConfigDialog)

--- a/src/app/navigation.tsx
+++ b/src/app/navigation.tsx
@@ -4,6 +4,8 @@ import SaveConfigDialog from "./save-config-dialog"
 import LoadConfigDialog from "./load-config-dialog"
 import Settings from "./settings"
 import { getName, getTauriVersion, getVersion } from "@tauri-apps/api/app";
+import { appConfigDir, join } from "@tauri-apps/api/path"
+import { readTextFile } from "@tauri-apps/api/fs"
 
 export default function Navigation({
     responsePaths,
@@ -32,16 +34,27 @@ export default function Navigation({
     const [appVersion, setAppVersion] = useState<string>("");
     const [appName, setAppName] = useState<string>("");
     const [tauriVersion, setTauriVersion] = useState<string>("");
+    const [configFilePath, setConfigFilePath] = useState<string>("")
+    const [savedConfigs, setSavedConfigs] = useState<[]>()
 
-      // Retrieves app name, app version, and tauri version from Tauri API
-  useEffect(() => {
-    async function fetchAppInfo() {
-      setAppVersion(await getVersion());
-      setAppName(await getName());
-      setTauriVersion(await getTauriVersion());
-    }
-    fetchAppInfo();
-  }, []);
+    // Retrieves app name, app version, and tauri version from Tauri API
+    useEffect(() => {
+        async function fetchAppInfo() {
+        setAppVersion(await getVersion());
+        setAppName(await getName());
+        setTauriVersion(await getTauriVersion());
+        }
+
+        async function getSavedConfigs() {
+            let configFile = await join(await appConfigDir(), "configurations.json");
+            let configFileData = JSON.parse(await readTextFile(configFile))
+            setConfigFilePath(configFile)
+            setSavedConfigs(configFileData)
+        }
+
+        fetchAppInfo();
+        getSavedConfigs();
+    }, []);
     return(
         <div>
             <div className="pt-10 bg-gray-300 fixed left-0 w-1/4 h-full flex flex-col">
@@ -100,6 +113,8 @@ export default function Navigation({
                             vh: viewSettings.vh,
                             vv: viewSettings.vv,
                         }}
+                        configFilePath={configFilePath}
+                        savedConfigs={savedConfigs}
                         toggleDialog={() =>
                             setShowSaveConfigDialog(!showSaveConfigDialog)
                         }
@@ -114,6 +129,7 @@ export default function Navigation({
                     {showLoadConfigDialog && (
                         <LoadConfigDialog
                         setConfig={setConfig}
+                        savedConfigs={savedConfigs}
                         toggleDialog={() =>
                             setShowLoadConfigDialog(!showLoadConfigDialog)
                         }

--- a/src/app/navigation.tsx
+++ b/src/app/navigation.tsx
@@ -5,7 +5,7 @@ import LoadConfigDialog from "./load-config-dialog"
 import Settings from "./settings"
 import { getName, getTauriVersion, getVersion } from "@tauri-apps/api/app";
 import { appConfigDir, join } from "@tauri-apps/api/path"
-import { readTextFile } from "@tauri-apps/api/fs"
+import { exists, readTextFile } from "@tauri-apps/api/fs"
 
 export default function Navigation({
     responsePaths,
@@ -47,7 +47,10 @@ export default function Navigation({
 
         async function getSavedConfigs() {
             let configFile = await join(await appConfigDir(), "configurations.json");
-            let configFileData = JSON.parse(await readTextFile(configFile))
+            let configFileData = []
+            if (await exists(configFile)) {
+                configFileData = JSON.parse(await readTextFile(configFile))
+            }
             setConfigFilePath(configFile)
             setSavedConfigs(configFileData)
         }

--- a/src/app/navigation.tsx
+++ b/src/app/navigation.tsx
@@ -4,6 +4,7 @@ import SaveConfigDialog from "./save-config-dialog"
 import LoadConfigDialog from "./load-config-dialog"
 import Settings from "./settings"
 import { getName, getTauriVersion, getVersion } from "@tauri-apps/api/app";
+import { invoke } from "@tauri-apps/api/tauri"
 
 export default function Navigation({
     responsePaths,
@@ -34,14 +35,23 @@ export default function Navigation({
     const [tauriVersion, setTauriVersion] = useState<string>("");
     const [savedConfigs, setSavedConfigs] = useState<[]>([]);
 
-    // Retrieves app name, app version, and tauri version from Tauri API
+    
+    // Loads the saved configurations from app config dir using a backend command
+    async function getSavedConfigs() {
+        const json: string = await invoke("get_saved_configs");
+        const configs = JSON.parse(json).configurations;
+        setSavedConfigs(configs);
+    }
+
     useEffect(() => {
+        // Retrieves app name, app version, and tauri version from Tauri API
         async function fetchAppInfo() {
         setAppVersion(await getVersion());
         setAppName(await getName());
         setTauriVersion(await getTauriVersion());
         }
 
+        getSavedConfigs();
         fetchAppInfo();
     }, []);
     return(
@@ -88,21 +98,22 @@ export default function Navigation({
                     {showSaveConfigDialog && (
                         <SaveConfigDialog
                         config={{
-                            responsePaths: responsePaths,
-                            feCorrectionPaths: fe_correctionPaths,
-                            vCorrectionPaths: v_correctionPaths,
-                            ndCorrectionPaths: nd_correctionPaths,
-                            cfCorrectionPaths: cf_correctionPaths,
+                            response_paths: responsePaths,
+                            fe_correction_paths: fe_correctionPaths,
+                            v_correction_paths: v_correctionPaths,
+                            nd_correction_paths: nd_correctionPaths,
+                            cf_correction_paths: cf_correctionPaths,
                             diameter: viewSettings.diameter,
                             xleft: viewSettings.xleft,
                             ydown: viewSettings.ydown,
                             // xres: viewSettings.xres,
                             // yres: viewSettings.yres,
-                            targetRes: viewSettings.targetRes,
+                            target_res: viewSettings.targetRes,
                             vh: viewSettings.vh,
                             vv: viewSettings.vv,
                         }}
                         savedConfigs={savedConfigs}
+                        setSavedConfigs={setSavedConfigs}
                         toggleDialog={() =>
                             setShowSaveConfigDialog(!showSaveConfigDialog)
                         }
@@ -118,6 +129,7 @@ export default function Navigation({
                         <LoadConfigDialog
                         setConfig={setConfig}
                         savedConfigs={savedConfigs}
+                        getSavedConfigs={getSavedConfigs}
                         toggleDialog={() =>
                             setShowLoadConfigDialog(!showLoadConfigDialog)
                         }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,16 +21,16 @@ export default function Home() {
           console.log("OS platform successfully queried:", platform);
         }
         // Default path for macOS and Linux
-        let defaultPath = "/usr/local/bin";
+        let radianceDefaultPath = "/usr/local/radiance/bin";
         // If platform is windows, update default path
         if (osPlatform === "windows") {
-          defaultPath = "C:\\bin";
+          radianceDefaultPath = "C:\\Radiance\\bin";
         }
         // Update settings
         setSettings({
-          radiancePath: defaultPath,
-          hdrgenPath: defaultPath,
-          raw2hdrPath: defaultPath,
+          radiancePath: radianceDefaultPath,
+          hdrgenPath: "",
+          raw2hdrPath: "",
           outputPath: settings.outputPath,
         });
       })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import Images from "./images";
 import CroppingResizingViewSettings from "./cropping-resizing-view-settings";
 import Navigation from "./navigation";
 import Response_and_correction from "./response_and_correction";
-import { appDataDir } from "@tauri-apps/api/path";
 
 const DEBUG = true;
 const fakePipeline = false;
@@ -33,7 +32,7 @@ export default function Home() {
           radiancePath: radianceDefaultPath,
           hdrgenPath: "",
           raw2hdrPath: "",
-          outputPath: await appDataDir(), // appDataDir queries Tauri for suggested place to store files 
+          outputPath: await invoke("get_default_output_path") // queries backend for suggested place to store files
         });
       })
       .catch(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -147,18 +147,18 @@ export default function Home() {
   };
 
   function setConfig(config: any) {
-    setResponsePaths(config.responsePaths);
-    set_fe_correctionPaths(config.fe_correctionPaths);
-    set_v_correctionPaths(config.v_correctionPaths);
-    set_nd_correctionPaths(config.nd_correctionPaths);
-    set_cf_correctionPaths(config.cf_correctionPaths);
+    setResponsePaths(config.response_paths);
+    set_fe_correctionPaths(config.fe_correction_paths);
+    set_v_correctionPaths(config.v_correction_paths);
+    set_nd_correctionPaths(config.nd_correction_paths);
+    set_cf_correctionPaths(config.cf_correction_paths);
     setViewSettings({
       diameter: config.diameter,
       xleft: config.xleft,
       ydown: config.ydown,
       // xres: viewSettings.xres,
       // yres: viewSettings.yres,
-      targetRes: config.targetRes,
+      targetRes: config.target_res,
       vh: config.vh,
       vv: config.vv,
     });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import Images from "./images";
 import CroppingResizingViewSettings from "./cropping-resizing-view-settings";
 import Navigation from "./navigation";
 import Response_and_correction from "./response_and_correction";
+import { appDataDir } from "@tauri-apps/api/path";
 
 const DEBUG = true;
 const fakePipeline = false;
@@ -14,24 +15,25 @@ export default function Home() {
   // Get default binary paths to populate settings fields based on OS
   useEffect(() => {
     let osPlatform = "";
-    // Make a call to the backend to get OS platform
+    // Make a call to the backend to get OS platform and set Radiance path
     invoke<string>("query_os_platform", {})
-      .then((platform: any) => {
+      .then(async (platform: any) => {
         if (DEBUG) {
           console.log("OS platform successfully queried:", platform);
         }
-        // Default path for macOS and Linux
+        // Default Radiance path for macOS and Linux
         let radianceDefaultPath = "/usr/local/radiance/bin";
-        // If platform is windows, update default path
+        // If platform is windows, update default Radiance path
         if (osPlatform === "windows") {
           radianceDefaultPath = "C:\\Radiance\\bin";
         }
+
         // Update settings
         setSettings({
           radiancePath: radianceDefaultPath,
           hdrgenPath: "",
           raw2hdrPath: "",
-          outputPath: settings.outputPath,
+          outputPath: await appDataDir(), // appDataDir queries Tauri for suggested place to store files 
         });
       })
       .catch(() => {
@@ -73,7 +75,7 @@ export default function Home() {
     radiancePath: "",
     hdrgenPath: "",
     raw2hdrPath: "",
-    outputPath: "/home/hdri-app/",
+    outputPath: "",
   });
 
   const handleSettingsChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/app/save-config-dialog.tsx
+++ b/src/app/save-config-dialog.tsx
@@ -1,7 +1,8 @@
+import { writeTextFile } from "@tauri-apps/api/fs";
 import { useState } from "react";
 
 // Modal used for saving the currently entered configuration to localStorage
-export default function SaveConfigDialog({ config, toggleDialog }: any) {
+export default function SaveConfigDialog({ config, configFilePath, savedConfigs, toggleDialog }: any) {
   const [configName, setConfigName] = useState<string>("");
   const [showError, setShowError] = useState<boolean>(false);
 
@@ -10,7 +11,6 @@ export default function SaveConfigDialog({ config, toggleDialog }: any) {
     if (configName.trim() != "") {
       // If name field is not empty
       config["name"] = configName;
-      let savedConfigs = JSON.parse(localStorage.getItem("configs") || "[]");
 
       // Search for existing config with this name
       let index = savedConfigs.findIndex((c: any) => c.name === configName);
@@ -30,11 +30,10 @@ export default function SaveConfigDialog({ config, toggleDialog }: any) {
       } else {
         savedConfigs.push(config);
       }
-      localStorage.setItem("configs", JSON.stringify(savedConfigs));
-      console.log(
-        "Saved configs: ",
-        JSON.parse(localStorage.getItem("configs") || "[]")
-      );
+
+      // Save updated configurations to config file
+      await writeTextFile(configFilePath, JSON.stringify(savedConfigs))
+
       handleCloseModal();
     } else {
       // If name field is empty or contains only white space, show error message

--- a/src/app/save-config-dialog.tsx
+++ b/src/app/save-config-dialog.tsx
@@ -1,8 +1,12 @@
-import { writeTextFile } from "@tauri-apps/api/fs";
+import { invoke } from "@tauri-apps/api/tauri";
 import { useState } from "react";
 
 // Modal used for saving the currently entered configuration to localStorage
-export default function SaveConfigDialog({ config, configFilePath, savedConfigs, toggleDialog }: any) {
+export default function SaveConfigDialog({
+  config,
+  savedConfigs,
+  toggleDialog,
+}: any) {
   const [configName, setConfigName] = useState<string>("");
   const [showError, setShowError] = useState<boolean>(false);
 
@@ -31,8 +35,8 @@ export default function SaveConfigDialog({ config, configFilePath, savedConfigs,
         savedConfigs.push(config);
       }
 
-      // Save updated configurations to config file
-      await writeTextFile(configFilePath, JSON.stringify(savedConfigs))
+      const result = await invoke("save_config", config);
+      console.log(result);
 
       handleCloseModal();
     } else {
@@ -66,9 +70,9 @@ export default function SaveConfigDialog({ config, configFilePath, savedConfigs,
                     later.
                   </p>
                   <p className="text-left text-sm py-5 max-w-lg">
-                    Note: This will only save paths to the calibration
-                    files, so the configuration will not work correctly if the
-                    files are moved.
+                    Note: This will only save paths to the calibration files, so
+                    the configuration will not work correctly if the files are
+                    moved.
                   </p>
                   <label className="font-bold block mb-2">Enter a name:</label>
                   <input

--- a/src/app/save-config-dialog.tsx
+++ b/src/app/save-config-dialog.tsx
@@ -5,13 +5,15 @@ import { useState } from "react";
 export default function SaveConfigDialog({
   config,
   savedConfigs,
+  setSavedConfigs,
   toggleDialog,
 }: any) {
   const [configName, setConfigName] = useState<string>("");
   const [showError, setShowError] = useState<boolean>(false);
 
-  // Saves configuration to localStorage with the specified name
+  // Saves configuration to app's config directory using backend command
   async function saveConfig() {
+    let updatedSavedConfigs = savedConfigs;
     if (configName.trim() != "") {
       // If name field is not empty
       config["name"] = configName;
@@ -30,13 +32,24 @@ export default function SaveConfigDialog({
           return;
         }
 
-        savedConfigs[index] = config;
+        updatedSavedConfigs[index] = config;
       } else {
-        savedConfigs.push(config);
+        updatedSavedConfigs.push(config);
       }
 
-      const result = await invoke("save_config", config);
-      console.log(result);
+      // Save configuration locally
+      setSavedConfigs(updatedSavedConfigs);
+
+      // Save configuration to the file system for retrieval later
+      invoke("save_config", config)
+        .then((result) => {
+          alert(result);
+          console.log(result);
+        })
+        .catch((e) => {
+          alert("An error occured while saving the configuration.");
+          console.error(e);
+        });
 
       handleCloseModal();
     } else {


### PR DESCRIPTION
# Changes

## Default Paths
- Updated default Radiance paths to be `/usr/local/radiance/bin` on macOS/Linux and `C:\Radiance\bin` on Windows.
- Updated HDRGen path to be an empty string. If HDRGen is in the user's path, I think this might actually still work without them changing this, but I'm not sure.
- Default output directory is now fetched using a Tauri command that uses `app_data_dir()` to get suggested data directory for the app. Once again, the Tauri API calls are causing a problem with the build, so I switched it to calling a BE command.
  - Example of default output path on my computer: `/Users/shantimorrell/Library/Application Support/hdricalibrationinterface`

## Saving/Loading Configurations
I found out I needed to use the backend here as well instead of calling Tauri's API from the frontend. Saving, loading, and retrieving saved configurations should all hopefully be working using the app's config folder returned by Tauri.

### Saving a configuration
Configurations are now saved by the backend fetching the app's config folder (and creating if need be), creating a new directory with the configuration name, copying all of the calibration files, and creating a json file with the view settings and the relative paths (just the file names in this case) of files copied into that folder. At the moment, files are renamed upon being copied into this folder.

### Retrieving saved configurations
There's also a backend function to retrieve all the saved configurations, which looks for the `configurations` directory and reads its contents (subdirectories for each configuration). I attempted to validate the configurations, and skip any that were invalid, though it's possible I missed something there. This function also edits the configurations and returns _absolute_ paths for the calibration files instead of the _relative_ paths, so that the frontend can access them correctly. (The `configuration.json` file has relative paths for each calibration file in that configuration. I left it this way thinking these folders could be zipped and shared between people, hopefully).

<br><br>

Closes radiantlab#96