### PR TITLE
Raw image support with dcraw_emu

### DIFF
--- a/src-tauri/src/pipeline/merge_exposures.rs
+++ b/src-tauri/src/pipeline/merge_exposures.rs
@@ -10,7 +10,7 @@ use super::ConfigSettings;
 // Merges multiple LDR images into an HDR image using hdrgen. If images are in JPG or TIFF format,
 // runs hdrgen command regularly. If images are not in JPG or TIFF format, converts the inputs
 // to TIFF raw images first using dcraw_emu, then runs hdrgen.
-// 
+//
 // input_images:
 //    vector of the paths to the input images. Input images must be in .JPG or .CR2 format.
 // response_function:
@@ -29,21 +29,7 @@ pub fn merge_exposures(
     }
 
     // Check whether images are in raw format that needs to be converted to TIF
-    let first_image_ext = Path::new(&input_images[0]).extension().unwrap_or_default();
-    let convert_to_tiff: bool = if input_images.len() > 0
-        && (first_image_ext == "jpg"
-            || first_image_ext == "JPG"
-            || first_image_ext == "jpeg"
-            || first_image_ext == "JPEG"
-            || first_image_ext == "tiff"
-            || first_image_ext == "TIFF"
-            || first_image_ext == "tif"
-            || first_image_ext == "TIF")
-    {
-        false
-    } else {
-        true
-    };
+    let convert_to_tiff: bool = input_images.len() > 0 && is_raw(&input_images[0]);
 
     if DEBUG {
         println!(
@@ -151,5 +137,21 @@ pub fn merge_exposures(
     } else {
         // On success, return output path of HDR image
         Ok(output_path.into())
+    }
+}
+
+// Returns a boolean representing whether the image file is in raw format. Returns false if JPG or TIF.
+fn is_raw(file_name: &String) -> bool {
+    let image_ext = Path::new(file_name)
+        .extension()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if image_ext == "jpg" || image_ext == "jpeg" || image_ext == "tiff" || image_ext == "tif" {
+        // Image is JPG or TIF
+        false
+    } else {
+        // Image is in raw format
+        true
     }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,7 +31,7 @@ export default function Home() {
         setSettings({
           radiancePath: radianceDefaultPath,
           hdrgenPath: "",
-          raw2hdrPath: "",
+          dcrawEmuPath: "",
           outputPath: await invoke("get_default_output_path") // queries backend for suggested place to store files
         });
       })
@@ -73,7 +73,7 @@ export default function Home() {
   const [settings, setSettings] = useState({
     radiancePath: "",
     hdrgenPath: "",
-    raw2hdrPath: "",
+    dcrawEmuPath: "",
     outputPath: "",
   });
 
@@ -116,7 +116,7 @@ export default function Home() {
     invoke<string>("pipeline", {
       radiancePath: settings.radiancePath,
       hdrgenPath: settings.hdrgenPath,
-      raw2hdrPath: settings.raw2hdrPath,
+      dcrawEmuPath: settings.dcrawEmuPath,
       outputPath: settings.outputPath,
       inputImages: devicePaths,
       responseFunction: responsePaths,

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -77,13 +77,13 @@ export default function Settings({
                       htmlFor="raw2hdrPath"
                       className="font-bold block h-full mr-5"
                     >
-                      raw2hdr Path
+                      dcraw_emu Path
                     </label>
                     <input
-                      id="raw2hdrPath"
-                      name="raw2hdrPath"
+                      id="dcrawEmuPath"
+                      name="dcrawEmuPath"
                       type="text"
-                      value={settings.raw2hdrPath}
+                      value={settings.dcrawEmuPath}
                       onChange={handleChange}
                       className="flex-grow placeholder:text-right w-max shadow appearance-none border border-gray-400 rounded py-2 px-3 leading-tight focus:outline-none focus:shadow-outline"
                     ></input>


### PR DESCRIPTION
# Raw Image Support
`raw2hdr` has been removed. If the images are not in JPG or TIFF format, the merge exposures step will first run `dcraw_emu` (from LibRaw: [https://www.libraw.org/](https://www.libraw.org/)) on each input image, outputting the converted TIFF image to the `tmp` folder. 

I had to run `dcraw_emu` on each input image separately, otherwise the converted images would be created in the directory the user selected, which I'm thinking might not be ideal, as they may not want to alter it. There wasn't a way (that I could find) to specify an output folder/path – it's only possible to specify one output file name – which would be rewritten if `dcraw_emu` is run on multiple images at a time. (Specifying output name rules for `dcraw_emu` is allowed with the `-Z` flag.)

## Note about supported image formats
Currently, the frontend only allows .JPG or .CR2 images to be selected. We'll probably want to update that to at least include TIFF and potentially other raw formats, since they can now be converted to TIFF with `dcraw_emu`? Additionally the backend only gathers .JPG, .TIFF, and .CR2 images from input directories at the moment. I can update this to match whatever formats we decide to support on the frontend.

### Other notes
- Added check that returns an error to frontend if no input images/directories are supplied. 
- `hdrgen` command now includes `-F` option, which will overwrite the file if it already exists. This allows the pipeline to successfully complete even if there was a previous run that wasn't deleted.
- Response function is now optional, and only added to `hdrgen` command if user selected one

<br><br>

Closes radiantlab#98 and closes radiantlab#95