### PR TITLE
Updated README, more validation of inputs, raw image previews hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,31 +9,35 @@
 
 
 ## Introduction
-The purpose of this application is to give the user a graphical user interface for the Radiance/HDRGen pipeline process. The program works by taking in multiple LDR image files and calibration files in order to return light calculated images containing radiance, luminance and color. The application is intended for interior light design researchers who are concerned with how lighting in a room affects visual discomfort.
+This application provides a graphical user interface for the creation and calibration of High Dynamic Range (HDR) images using Radiance, hdrgen, and dcraw_emu according to the pipeline process published [here](https://www.tandfonline.com/doi/full/10.1080/15502724.2019.1684319). The program works by taking in multiple LDR image files as well as some calibration information related to the camera/lens used, in order to return calibrated HDR images, also called luminance maps. The application is intended for lighting and daylighting professionals or researchers who are interested in studying the indoor visual environment and especially discomfort glare.
 
 ## Platforms
-This application runs on MacOS, Windows and Linux.
+This application runs on macOS, Windows and Linux.
 
 ## Getting Started
-The user must install [Radiance](https://www.radiance-online.org/) as well as [HDRGen](http://www.anyhere.com/) to their local machine and have access to their location. After the dependencies have been installed, install the [HDRI Calibration Interface](https://github.com/shantimorrell/HDRICalibrationTool-Capstone/actions/runs/8283470432). There will be a build for each platform. After installation, extract the contents of the zipped folder to a desired location. Open the installed `folder/bundle` and the first folder in here will contain the installation for your platform. Continue the installation process. This will install the application on your desktop.
+Install [Radiance](https://www.radiance-online.org/), [hdrgen](http://www.anyhere.com/), and the [dcraw_emu binary from LibRaw](https://www.libraw.org/download) to your local machine and note where these tools are located (the folder path). After these dependencies have been installed, install the [HDRI Calibration Interface](https://github.com/radiantlab/HDRICalibrationTool/releases/latest).
 
 ## Use
 ### Uploading Images
-Open the application created by the installer in the previous step. You should be able to see the main page of the program. Next you will need to upload the images in the image selection section by clicking the select button. Optionally, you can select a folder that contains the images you will be uploading. The filetypes supported are JPG, JPEG and raw image format. After uploading the images, you should see a preview of the images and the image count should reflect the number of uploaded images.
+Open the application created by the installer in the previous step. You should be able to see the main page of the program. Next you will need to upload the images in the image selection section by clicking the select button. Optionally, you can select a folder that contains the images you will be uploading. The filetypes supported are JPG, TIF, and raw image formats. After uploading the images, you should see a list of the images and the image count should reflect the number of uploaded images.
 
 ### Uploading Response File and Image Information
-Upload the response file that should have a file extension of rsp and fill in the image data for the cropping, resizing and view settings.
+Upload the response file that should have a file extension of `.rsp` and fill in the image data for the cropping, resizing and view settings.
 
 ### Uploading Calibration Files
-Select the calibration files for the remaining fields. These should have a cal file extension.
+Upload the calibration files for the remaining fields. These should have a `.cal` file extension.
 
 ### Settings
-Click on the settings tab in the left hand navigation sidebar and you should see a settings display appear. For the Radiance path, give the path to the Radiance binaries. This would be something like `/usr/local/radiance/bin/` with usr being the name of the user on the computer. The HDRGen path should point to /usr/local/bin and the output should point to the location to which you want the output images to go to.
+Click on the settings tab in the left hand navigation sidebar and you should see a settings display appear. For the Radiance path, give the path to the Radiance binaries. This would be something like `/usr/local/radiance/bin/` on macOS or Linux and `C:\Radiance\bin` on Windows. For hdrgen and dcraw_emu, provide the path to the folder where hdrgen and dcraw_emu were installed. These should be something like `/usr/local/bin`. Lastly, the output should point to the folder to which you want the output images to be saved to.
 
 ### Generate Images
-Once settings are entered, you can close the settings and click the Generate HDR Image button in the navigation sidebar which will give a message about the process that will either complete or give an error.
+Once settings are entered, you can close the settings and click the Generate HDR Image button in the navigation sidebar. A message will let you know about the process or give you an error if something is wrong.
+
+## Additional Resources
+For further guidance about creating and calibrating HDR images, please consult [Tutorial: Luminance Maps for Daylighting Studies from High Dynamic Range Photography](https://www.tandfonline.com/doi/full/10.1080/15502724.2019.1684319) by Clotilde Pierson, Coralie Cauwerts, Magali Bodart, and Jan Wienold.
 
 ## Acknowledgements
+This app builds upon the scene processing and simulation strengths of existing programs such as Radiance, hdrgen, and LibRaw.
 
 ### Authors
 - Dr. Clotilde Pierson (Oregon State University)

--- a/src/app/images.tsx
+++ b/src/app/images.tsx
@@ -28,6 +28,8 @@ export default function Images({
     // Error checking display
     const [image_error, set_image_error] = useState<boolean>(false);
 
+    const [rawImagesSelected, setRawImagesSelected] = useState<boolean>(false);
+
     // Open a file dialog window using the tauri api and update the images array with the results
     async function dialog() {
         if (directorySelected == true) {
@@ -109,6 +111,17 @@ export default function Images({
         reset();
     };
 
+    // Update flag for whether raw images are selected (to determine whether to show image previews)
+    useEffect(() => {
+        setRawImagesSelected(false)
+        for (let i = 0; i < images.length; i++) {
+            const ext = Extensions(String(images[i])).toLowerCase()
+            if (ext !== "jpeg" && ext !== "jpg" && ext !== "tif" && ext !== "tiff") {
+                setRawImagesSelected(true)
+            }
+        }
+    }, [images])
+
     return (
         <div>
             <button
@@ -137,9 +150,10 @@ export default function Images({
                     <label>Select directories</label>
                 </div>
             </div>
-            {directorySelected ? (
+            {directorySelected || rawImagesSelected ? (
                 <div>
-                    <div>Directory count: {devicePaths.length}</div>
+                    {directorySelected && <div>Directory count: {devicePaths.length}</div>}
+                    {rawImagesSelected && <div>Image count: {devicePaths.length}</div>}
                     <div className="directory-preview flex flex-wrap flex-col">
                         {devicePaths.map((path: any, index: any) => (
                             <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -114,9 +114,30 @@ export default function Home() {
 
   // Calls the BE pipeline function with the input images the user
   // selected, and hardcoded data for the rest of the inputs
-  const handleGenerateHDRImage = () => {
+  const handleGenerateHDRImage = async () => {
+    // Validate inputs
+    if (!allInputsEntered()) {
+      // If a calibration file or view setting is missing, or the user hasn't selected input images/dirs, display error and abort
+      alert(
+        "You must enter all calibration files and view settings and select input images or directories before generating an HDR image."
+      );
+      return;
+    } else if (!responsePaths) {
+      // If the user didn't select a response function, 
+      // display a warning that the output HDR image might be inaccurate if converting from JPEG
+      // and ask for confirmation before proceeding with pipeline call
+      let proceed = await confirm(
+        "Warning: No response function selected. If you're converting JPEG images, the automatically generated response function may result in an inaccurate HDR image. Continue anyway?"
+      );
+      if (!proceed) {
+        return;
+      }
+    }
+
     // Progress
     setShowProgress(true);
+
+    // Call pipeline
     invoke<string>("pipeline", {
       radiancePath: settings.radiancePath,
       hdrgenPath: settings.hdrgenPath,
@@ -148,6 +169,26 @@ export default function Home() {
           setProcessError(true);
         }
       });
+  };
+
+  function allInputsEntered() {
+    if (
+      devicePaths.length === 0 || 
+      !fe_correctionPaths ||
+      !v_correctionPaths ||
+      !cf_correctionPaths ||
+      !nd_correctionPaths ||
+      !viewSettings.diameter ||
+      !viewSettings.xleft ||
+      !viewSettings.ydown ||
+      !viewSettings.targetRes ||
+      !viewSettings.vh ||
+      !viewSettings.vv
+    ) {
+      return false;
+    } else {
+      return true;
+    }
   };
 
   function setConfig(config: any) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,6 +40,8 @@ export default function Home() {
       .catch(() => {
         console.error;
       });
+
+    alert("Please enter the paths to the HDRGen and dcraw_emu binaries in the settings before generating HDR images.")
   }, []);
 
   // Holds the fisheye coordinates and view settings

--- a/src/app/progress.tsx
+++ b/src/app/progress.tsx
@@ -54,7 +54,12 @@ export default function Progress({
                             {!progressButton && processError && (
                                 <div>
                                     <h2>Error</h2>
-                                    <div>Please Ensure Inputs Are Correct</div>
+                                    <p className=" text-sm pt-1">
+                                        There was an error with the pipeline. Please make sure all
+                                        the inputs are correct, and that you have entered the
+                                        paths for the HDRGen and dcraw_emu binaries in the 
+                                        settings.
+                                    </p>
                                     <button
                                         onClick={() => ResetProgress()}
                                         className="bg-gray-300 hover:bg-gray-400 text-gray-700 font-semibold py-1 px-2 m-10 border-gray-400 rounded h-fit"


### PR DESCRIPTION
## Updates to README
Based on Clotilde's feedback, I updated a number of things about the README. The most major things are:
- Including mention of dcraw_emu binary from LibRaw as a dependency
- Linking Clotilde's tutorial in _Introduction_, and also in the _Additional Resources_ section.
- Updating installation instructions
  - The way the publish workflow works is slightly different than the test workflow, but I think it should just be actual files now, so I changed the documentation to reflect that. See this screenshot from when I tested the release workflow a week ago: 
  <img width="1248" alt="Screenshot displaying the assets uploaded in a test repository. File names for the individual builds for each platform are listed." src="https://github.com/shantimorrell/HDRICalibrationTool-Capstone/assets/91344787/2b1b0b00-d242-472a-8c5e-df8942604cfb">
- Added acknowledgement for Radiance, hdrgen, and LibRaw as per Clotilde's suggestion
- Adjustments to the paths listed in the _Settings_ section

## Requiring All Inputs Except Response Function
Now, as Clotilde suggested, all calibration files and view settings are required to generate an HDR image. If something is missing, or no input images are selected, a message displays letting the user know they need to enter all inputs.

## Warning for No Response Function
If the user does not upload a response function, a message displays warning them that if they're converting from JPG, the automatically generated response function might result in an inaccurate HDR image. If the user wishes, they can confirm and still proceed without a response function.

## Image Previews
Image previews are now hidden for raw images. The file names are displayed like the directory names.

<br><br>

Closes radiantlab#102, closes radiantlab#78, closes radiantlab#103